### PR TITLE
microunit: integrate axum and implement some simple APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "axum"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49c3f630b925c7a85089ff794fdce495c88c80d38710f31eb9817c8399fd77ce"
+dependencies = [
+ "async-trait",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "matchit",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "background"
 version = "0.1.0"
 dependencies = [
@@ -42,6 +71,18 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -80,6 +121,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "engula-framework",
+ "tokio",
 ]
 
 [[package]]
@@ -102,6 +144,73 @@ name = "engula-platform"
 version = "0.1.0"
 dependencies = [
  "storage",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+
+[[package]]
+name = "futures-task"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+
+[[package]]
+name = "futures-util"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+dependencies = [
+ "autocfg",
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -129,6 +238,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+
+[[package]]
+name = "httpdate"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+
+[[package]]
+name = "hyper"
+version = "0.14.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +303,21 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "lazy_static"
@@ -151,11 +332,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
 
 [[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "manifest"
 version = "0.1.0"
 dependencies = [
  "async-trait",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "matchit"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b6f41fdfbec185dd3dff58b51e323f5bc61692c0de38419a957b0dcfccca3c"
 
 [[package]]
 name = "memchr"
@@ -166,6 +377,67 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 [[package]]
 name = "microunit"
 version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "os_str_bytes"
@@ -175,6 +447,69 @@ checksum = "addaa943333a514159c80c97ff4a93306530d965d27e139188283cd13e06a799"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pin-project"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro-error"
@@ -219,6 +554,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "serde"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
+name = "socket2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "storage"
 version = "0.1.0"
 dependencies = [
@@ -243,6 +667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +689,135 @@ checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "tokio"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00e500fff5fa1131c866b246041a6bf96da9c965f8fe4128cb1421f23e93c00"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b56efe69aa0ad2b5da6b942e57ea9f6fe683b7a314d4ff48662e2c8838de1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+
+[[package]]
+name = "tracing"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+dependencies = [
+ "cfg-if",
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "unicase"
@@ -288,10 +847,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+ "serde",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/src/engula-framework/microunit/Cargo.toml
+++ b/src/engula-framework/microunit/Cargo.toml
@@ -2,5 +2,12 @@
 name = "microunit"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
+async-trait = "0.1"
+axum = "0.3"
+tokio = "1.13"
+uuid = { version = "0.8", features = ["serde", "v4"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/src/engula-framework/microunit/src/error.rs
+++ b/src/engula-framework/microunit/src/error.rs
@@ -17,4 +17,10 @@ pub enum Error {
     InvalidArgument,
 }
 
+impl ToString for Error {
+    fn to_string(&self) -> String {
+        format!("{:?}", self)
+    }
+}
+
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/engula-framework/microunit/src/error.rs
+++ b/src/engula-framework/microunit/src/error.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub struct Error {}
+#[derive(Debug)]
+pub enum Error {
+    InvalidArgument,
+}
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/engula-framework/microunit/src/lib.rs
+++ b/src/engula-framework/microunit/src/lib.rs
@@ -17,9 +17,11 @@ mod node;
 mod node_server;
 mod unit;
 
+pub use async_trait::async_trait;
+
 pub use self::{
     error::{Error, Result},
-    node::Node,
+    node::{Node, NodeBuilder},
     node_server::NodeServer,
     unit::{Unit, UnitBuilder, UnitDesc, UnitSpec},
 };

--- a/src/engula-framework/microunit/src/node.rs
+++ b/src/engula-framework/microunit/src/node.rs
@@ -12,24 +12,73 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
 use crate::{
-    error::Result,
-    unit::{UnitDesc, UnitSpec},
+    error::{Error, Result},
+    unit::{Unit, UnitBuilder, UnitDesc, UnitSpec},
 };
 
+#[derive(Default)]
+pub struct NodeBuilder {
+    unit_builders: HashMap<String, Box<dyn UnitBuilder>>,
+}
+
+impl NodeBuilder {
+    pub fn unit(mut self, builder: impl UnitBuilder + 'static) -> NodeBuilder {
+        let kind = builder.kind().to_owned();
+        assert!(self.unit_builders.insert(kind, Box::new(builder)).is_none());
+        self
+    }
+
+    pub fn build(self) -> Node {
+        let core = Core {
+            units: HashMap::new(),
+            unit_builders: self.unit_builders,
+        };
+        Node {
+            core: Mutex::new(core),
+        }
+    }
+}
+
 /// A node manages a set of units.
-pub struct Node {}
+pub struct Node {
+    core: Mutex<Core>,
+}
 
 impl Node {
     pub async fn list_units(&self) -> Vec<UnitDesc> {
-        Vec::new()
+        let core = self.core.lock().await;
+        let mut descs = Vec::new();
+        for unit in core.units.values() {
+            descs.push(unit.desc().await);
+        }
+        descs
     }
 
-    pub async fn create_unit(&self, _unit: &UnitSpec) -> Result<()> {
-        Ok(())
+    pub async fn create_unit(&self, spec: UnitSpec) -> Result<UnitDesc> {
+        let mut core = self.core.lock().await;
+        if let Some(builder) = core.unit_builders.get(&spec.kind) {
+            let id = Uuid::new_v4().to_string();
+            let unit = builder.spawn(id.clone(), spec).await?;
+            let desc = unit.desc().await;
+            assert!(core.units.insert(id, unit).is_none());
+            Ok(desc)
+        } else {
+            Err(Error::InvalidArgument)
+        }
     }
 
     pub async fn delete_unit(&self, _uid: &str) -> Result<()> {
         Ok(())
     }
+}
+
+struct Core {
+    units: HashMap<String, Box<dyn Unit>>,
+    unit_builders: HashMap<String, Box<dyn UnitBuilder>>,
 }

--- a/src/engula-framework/microunit/src/node_server.rs
+++ b/src/engula-framework/microunit/src/node_server.rs
@@ -18,11 +18,9 @@ use axum::{
     extract::Extension, http::StatusCode, response::IntoResponse, routing::get, AddExtensionLayer,
     Json, Router, Server,
 };
+use serde_json::json;
 
-use crate::{
-    node::Node,
-    unit::{UnitDesc, UnitSpec},
-};
+use crate::{node::Node, unit::UnitSpec};
 
 /// An HTTP server that serves a node.
 pub struct NodeServer {
@@ -55,7 +53,17 @@ async fn create_unit(
     Extension(node): Extension<Arc<Node>>,
 ) -> impl IntoResponse {
     match node.create_unit(spec).await {
-        Ok(desc) => (StatusCode::CREATED, Json(desc)),
-        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, Json(UnitDesc::default())),
+        Ok(desc) => {
+            let resp = json!({
+                "desc": desc,
+            });
+            (StatusCode::CREATED, Json(resp))
+        }
+        Err(err) => {
+            let resp = json!({
+                "error": err.to_string(),
+            });
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(resp))
+        }
     }
 }

--- a/src/engula-framework/microunit/src/unit.rs
+++ b/src/engula-framework/microunit/src/unit.rs
@@ -12,18 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
 use crate::error::Result;
 
 /// A unit description that describes the current state of a unit.
-pub struct UnitDesc {}
+#[derive(Serialize, Deserialize, Default)]
+pub struct UnitDesc {
+    pub id: String,
+}
 
 /// A unit specification that specifies the desired state of a unit.
-pub struct UnitSpec {}
+#[derive(Serialize, Deserialize, Default)]
+pub struct UnitSpec {
+    pub kind: String,
+}
 
 /// A unit handle.
-pub trait Unit {}
+#[async_trait]
+pub trait Unit: Send + Sync {
+    async fn desc(&self) -> UnitDesc;
+}
 
 /// A unit builder spawns a specific kind of units.
-pub trait UnitBuilder {
-    fn spawn(&self, spec: UnitSpec) -> Result<Box<dyn Unit>>;
+#[async_trait]
+pub trait UnitBuilder: Send + Sync {
+    fn kind(&self) -> &str;
+
+    async fn spawn(&self, id: String, spec: UnitSpec) -> Result<Box<dyn Unit>>;
 }

--- a/src/engula/Cargo.toml
+++ b/src/engula/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 engula-framework = { path = "../engula-framework" }
 clap = "3.0.0-beta.5"
+tokio = { version = "1", features = ["full"] }

--- a/src/engula/src/hello_unit.rs
+++ b/src/engula/src/hello_unit.rs
@@ -12,33 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use clap::{crate_version, Parser};
+use engula_framework::microunit::{async_trait, Result, Unit, UnitBuilder, UnitDesc, UnitSpec};
 
-mod hello_unit;
-mod node;
-
-#[derive(Parser)]
-#[clap(version = crate_version!())]
-struct Command {
-    #[clap(subcommand)]
-    subcmd: SubCommand,
+pub struct HelloUnit {
+    id: String,
 }
 
-impl Command {
-    async fn run(&self) {
-        match &self.subcmd {
-            SubCommand::Node(cmd) => cmd.run().await,
+#[async_trait]
+impl Unit for HelloUnit {
+    async fn desc(&self) -> UnitDesc {
+        UnitDesc {
+            id: self.id.clone(),
         }
     }
 }
 
-#[derive(Parser)]
-enum SubCommand {
-    Node(node::Command),
-}
+#[derive(Default)]
+pub struct HelloUnitBuilder {}
 
-#[tokio::main]
-async fn main() {
-    let cmd: Command = Command::parse();
-    cmd.run().await;
+#[async_trait]
+impl UnitBuilder for HelloUnitBuilder {
+    fn kind(&self) -> &str {
+        "hello"
+    }
+
+    async fn spawn(&self, id: String, _spec: UnitSpec) -> Result<Box<dyn Unit>> {
+        let unit = HelloUnit { id };
+        Ok(Box::new(unit))
+    }
 }

--- a/src/engula/src/node.rs
+++ b/src/engula/src/node.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use clap::{crate_version, Parser};
-use engula_framework::microunit::{Node, NodeServer};
+use engula_framework::microunit::{NodeBuilder, NodeServer};
+
+use crate::hello_unit::HelloUnitBuilder;
 
 #[derive(Parser)]
 #[clap(version = crate_version!())]
@@ -23,9 +25,9 @@ pub struct Command {
 }
 
 impl Command {
-    pub fn run(&self) {
+    pub async fn run(&self) {
         match &self.subcmd {
-            SubCommand::Start(cmd) => cmd.run(),
+            SubCommand::Start(cmd) => cmd.run().await,
         }
     }
 }
@@ -41,8 +43,11 @@ struct StartCommand {
 }
 
 impl StartCommand {
-    fn run(&self) {
+    async fn run(&self) {
         let addr = self.addr.parse().unwrap();
-        NodeServer::bind(&addr).serve(Node {});
+        let node = NodeBuilder::default()
+            .unit(HelloUnitBuilder::default())
+            .build();
+        NodeServer::bind(addr).serve(node).await;
     }
 }


### PR DESCRIPTION
We have an HTTP server that actually does something now :)

## Usage

Start a node:

```
cargo run -p engula -- node start 127.0.0.1:8000
```

Then create a unit with `curl`:

```
curl --header "Content-Type: application/json" --request POST --data '{"kind": "hello"}' http://127.0.0.1:8000/units
```

Then list all units:

```
curl http://127.0.0.1:8000/units
```

Check https://github.com/engula/engula/pull/72/files#diff-668b2c825f579fdebdae0903e9cf9e2a7aa615af9cab7831a592b8b977f5edf9 for the programming API of microunit.

In a typical scenario, the `Unit` implementation will be a client that talks to a server in another process.