### PR TITLE
docs: add journal design document

### DIFF
--- a/docs/images/journal-architecture.drawio.svg
+++ b/docs/images/journal-architecture.drawio.svg
@@ -1,0 +1,248 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="921px" height="281px" viewBox="-0.5 -0.5 921 281" content="&lt;mxfile&gt;&lt;diagram id=&quot;azTu9tN_7o5MFllLaFx0&quot; name=&quot;Page-1&quot;&gt;7Vldk5owFP01vHZIIh++ruu20+6+1Id2H1O4At1AnBgV++sb8CIw6G6ni6Azqz6Yk3tDcg65R6LFZmn+WfFV/CRDEBa1w9xi9xalhFBqFR873B8Q3/YOQKSSEINqYJH8AQRtRDdJCOtWoJZS6GTVBgOZZRDoFsaVkrt22FKK9lVXPIIOsAi46KI/klDHuArHrvEvkERxdWViY0/Kq2AE1jEP5a4BsbnFZkpKffiW5jMQBXkVL4e8hzO9x4kpyPQ/JUxwHnpfLU7JTRZC0W9b7E4qHctIZlw8SrkyIDHgb9B6j7LwjZYGinUqsBfyRP8s0j852Hpu9NznOHLZ2FeNTKt9I6loPjf76rSydcwLjTA493qq8xq9W7+ADmKcwGGxRdJZvhBay40KMArvVs1VBFUUPYpl7nKQKZhZmRgFgutk2x6e4+0WHeNqRcwXFOWMQE5HoLfXfFMSXkYgZyh93A99/kef6UD64KW3XGxw0K9mYobrN+reLk40LFa8XMLO2FhbgBYpy0SImRRSlQOxpVO8iyCt5As0etzyVWTITDfww+tI7xaUhvx1grvUYcJkgtaC3lo1d7VRkcp94oZJVXHv2gz+uJuB3sRucLq7wR2qWk3HFci7VYG8gQRyOuXqO6RSg8EuXrdCB/xwcqpu+fQXK+vWBeoTcQcsUO55N7AXoLaJoa0/fntgi7lttsyj0nBsebfGlkNHZOv4SPdhfq/U1mm3thL7tKj9/xYk4yp0G+53SqEz2653haadijPPNWDJubgBAjEW6J0ywKnrMd6TAXruiAZYnaA1GP7Gly/8uuq4649YxwnpUPQoo3u4PrvzJ2PS5H3Y3dvFlJw6O2RD+R17t0QtCq7d/PqTiA52vNs9n3qUwTB2F3Lwl8HJc6rAh1/LfooUoWPaHevQ+2Sep3GQqynkY9Zx2r0DHxJRHDgs9msN6XUxRe3hqDLN+o+4sq/xdyab/wU=&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <path d="M 460 40 L 460 80 L 140 80 L 140 113.63" fill="none" stroke="none" pointer-events="stroke"/>
+        <path d="M 140 118.88 L 136.5 111.88 L 140 113.63 L 143.5 111.88 Z" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 460 40 M 460 40 C 460.43 47.01 460.23 56.06 460 80 M 460 40 C 459.94 51.16 461.23 63.17 460 80 M 460 80 C 344.48 78.96 232.18 78.6 140 80 M 460 80 C 392.24 80.15 323.85 79.97 140 80 M 140 80 C 138.77 92.59 141.46 103.7 140 113.63 M 140 80 C 140.07 92.04 139.65 105.86 140 113.63" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 136.36 112.04 C 136.36 112.04 136.36 112.04 136.36 112.04 M 136.36 112.04 C 136.36 112.04 136.36 112.04 136.36 112.04 M 138.72 115.42 C 139.03 114.84 139.82 114.24 140.03 113.91 M 138.72 115.42 C 139.05 115.15 139.3 114.8 140.03 113.91" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 140 118.88 M 140 118.88 C 138.35 116.73 138.18 114.01 136.5 111.88 M 140 118.88 C 138.54 115.86 137.04 113.56 136.5 111.88 M 136.5 111.88 C 137.36 112.2 138 112.97 140 113.63 M 136.5 111.88 C 137.5 112.33 138.3 112.6 140 113.63 M 140 113.63 C 140.93 113.17 142.98 112.43 143.5 111.88 M 140 113.63 C 140.72 113.24 141.93 112.81 143.5 111.88 M 143.5 111.88 C 142.06 115.13 141.05 117.09 140 118.88 M 143.5 111.88 C 142.99 113.88 142.06 115.17 140 118.88" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 460 40 L 460 113.63" fill="none" stroke="none" pointer-events="stroke"/>
+        <path d="M 460 118.88 L 456.5 111.88 L 460 113.63 L 463.5 111.88 Z" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 460 40 M 460 40 C 459.28 57.08 457.9 69.44 460 113.63 M 460 40 C 461.44 66.37 460.3 92.6 460 113.63" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 456.4 112 C 456.4 112 456.4 112 456.4 112 M 456.4 112 C 456.4 112 456.4 112 456.4 112 M 458.76 115.38 C 459.09 114.96 459.81 114.18 460.07 113.87 M 458.76 115.38 C 459.24 114.81 459.81 114.17 460.07 113.87" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 460 118.88 M 460 118.88 C 458.25 117.45 457.42 114.02 456.5 111.88 M 460 118.88 C 458.85 117.03 458.31 115.42 456.5 111.88 M 456.5 111.88 C 457.55 112.43 458.79 113.02 460 113.63 M 456.5 111.88 C 457.04 112.22 458.1 112.77 460 113.63 M 460 113.63 C 460.84 112.96 461.84 112.78 463.5 111.88 M 460 113.63 C 461.24 113.05 462.42 112.23 463.5 111.88 M 463.5 111.88 C 463.17 113.63 461.41 115.81 460 118.88 M 463.5 111.88 C 462.79 113.64 461.59 114.81 460 118.88" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 460 40 L 460 80 L 780 80 L 780 113.63" fill="none" stroke="none" pointer-events="stroke"/>
+        <path d="M 780 118.88 L 776.5 111.88 L 780 113.63 L 783.5 111.88 Z" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 460 40 M 460 40 C 458.28 48.94 459.72 58.39 460 80 M 460 40 C 460.44 49.35 460.88 59.55 460 80 M 460 80 C 534.29 78.6 605.12 79.18 780 80 M 460 80 C 575.64 77.77 692.99 77.29 780 80 M 780 80 C 781.48 88.26 780.12 99.78 780 113.63 M 780 80 C 780.08 88.34 779.71 97.97 780 113.63" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 776.44 111.95 C 776.44 111.95 776.44 111.95 776.44 111.95 M 776.44 111.95 C 776.44 111.95 776.44 111.95 776.44 111.95 M 778.14 116.08 C 778.88 115.53 778.86 115.14 780.11 113.82 M 778.14 116.08 C 778.7 115.24 779.63 114.32 780.11 113.82" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 780 118.88 M 780 118.88 C 779.72 116.6 778.24 115.59 776.5 111.88 M 780 118.88 C 779.25 116.81 778.18 115.25 776.5 111.88 M 776.5 111.88 C 777.83 112.32 778.96 113.16 780 113.63 M 776.5 111.88 C 777.71 112.46 778.94 113.25 780 113.63 M 780 113.63 C 781.46 113.18 782.1 112.43 783.5 111.88 M 780 113.63 C 781.06 113.21 781.9 112.74 783.5 111.88 M 783.5 111.88 C 781.87 113.53 781.8 117.33 780 118.88 M 783.5 111.88 C 781.88 114.79 780.51 117.25 780 118.88" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="400" y="0" width="120" height="40" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 400.31 -0.36 C 400.31 -0.36 400.31 -0.36 400.31 -0.36 M 400.31 -0.36 C 400.31 -0.36 400.31 -0.36 400.31 -0.36 M 400.05 6.04 C 402.71 3.29 403.86 1.01 405.3 0 M 400.05 6.04 C 401.31 4.81 402.51 2.48 405.3 0 M 399.79 12.44 C 403.26 7.36 407.44 5.4 410.29 0.36 M 399.79 12.44 C 401.81 9.61 405.42 6.41 410.29 0.36 M 400.18 18.08 C 403.99 13.16 408.27 8.95 415.93 -0.03 M 400.18 18.08 C 404.77 13.29 409.84 7.87 415.93 -0.03 M 399.92 24.48 C 406.3 13.86 417.12 5.85 420.92 0.33 M 399.92 24.48 C 406.04 16.34 413.12 9.22 420.92 0.33 M 400.32 30.12 C 411.92 18.33 418.31 8.37 426.56 -0.07 M 400.32 30.12 C 407.43 23.64 413.37 15.35 426.56 -0.07 M 400.05 36.52 C 410.78 24.71 422.75 9.72 431.55 0.29 M 400.05 36.52 C 412.3 23.59 422.93 10.95 431.55 0.29 M 401.11 41.41 C 411.43 32.03 417.59 21.58 437.19 -0.1 M 401.11 41.41 C 408.26 31.93 417.27 22.4 437.19 -0.1 M 406.75 41.01 C 418.53 29.26 428.9 16.27 442.18 0.26 M 406.75 41.01 C 414.54 32.82 421.86 23.59 442.18 0.26 M 411.74 41.37 C 425.77 26.73 436.28 12.14 447.82 -0.14 M 411.74 41.37 C 423.1 28.82 434.3 14.72 447.82 -0.14 M 417.38 40.98 C 429.67 26.33 440.35 15.12 452.81 0.22 M 417.38 40.98 C 424.56 31.3 433.67 22.74 452.81 0.22 M 422.37 41.34 C 432.26 30.49 441.63 19.8 458.45 -0.17 M 422.37 41.34 C 433.2 29.82 445.28 16.96 458.45 -0.17 M 428.01 40.94 C 441.86 24.18 456.32 8.18 463.44 0.19 M 428.01 40.94 C 439.37 28.89 449.84 16.15 463.44 0.19 M 433 41.3 C 443.37 27 456.17 16.02 469.08 -0.21 M 433 41.3 C 442.28 32.48 449.78 22.78 469.08 -0.21 M 438.64 40.91 C 450.65 25.2 466.61 12.33 474.07 0.15 M 438.64 40.91 C 447.87 31.3 456.52 21.57 474.07 0.15 M 443.63 41.27 C 457.82 26.78 469.61 8.88 479.71 -0.24 M 443.63 41.27 C 454.21 28.36 464.55 18.06 479.71 -0.24 M 449.27 40.87 C 460.6 29.71 469.88 17.2 484.7 0.12 M 449.27 40.87 C 455.93 31.1 464.64 23.71 484.7 0.12 M 454.26 41.23 C 466.44 27.63 474.71 14.84 490.34 -0.27 M 454.26 41.23 C 463.01 31.32 473.58 20 490.34 -0.27 M 459.9 40.84 C 466.68 33.09 476.35 22.62 495.33 0.09 M 459.9 40.84 C 468.87 29.67 478.7 18.69 495.33 0.09 M 464.89 41.2 C 475.01 31.14 480.96 22.74 500.97 -0.31 M 464.89 41.2 C 472.78 31.66 481.14 22.16 500.97 -0.31 M 470.53 40.81 C 482.49 26.51 494.66 11.07 505.96 0.05 M 470.53 40.81 C 483.5 24.39 498.4 9.01 505.96 0.05 M 475.52 41.17 C 483.91 27.31 495.34 14.88 511.6 -0.34 M 475.52 41.17 C 489.53 24.48 502.92 9.32 511.6 -0.34 M 480.5 41.53 C 493.53 26.59 505.5 13.8 516.59 0.02 M 480.5 41.53 C 489.72 29.88 501.74 16.92 516.59 0.02 M 486.15 41.13 C 496.88 25.51 511.9 11.04 520.92 1.13 M 486.15 41.13 C 499.91 25.25 512.18 10.35 520.92 1.13 M 491.13 41.49 C 504.37 26.52 515.7 12.52 521.31 6.77 M 491.13 41.49 C 498.16 32.58 506.27 22.92 521.31 6.77 M 496.78 41.1 C 504.65 32.87 509.47 27.07 521.05 13.17 M 496.78 41.1 C 503.28 32.91 511.08 23.23 521.05 13.17 M 501.76 41.46 C 509.94 33.14 516.98 25.95 520.79 19.57 M 501.76 41.46 C 506.06 37.33 510.1 31.19 520.79 19.57 M 507.41 41.06 C 511.31 33.8 515.1 30.25 521.18 25.21 M 507.41 41.06 C 512.37 34.54 518.93 29.37 521.18 25.21 M 512.39 41.42 C 513.61 38.74 516.16 34.54 520.92 31.61 M 512.39 41.42 C 514.78 37.93 517.42 35.92 520.92 31.61 M 518.04 41.03 C 519.24 40.09 519.75 38.7 521.32 37.25 M 518.04 41.03 C 519.26 39.83 520.18 38.85 521.32 37.25" fill="none" stroke="#f5f5f5" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 400 0 C 425.48 -2.42 446.19 -2.28 520 0 M 400 0 C 427.67 0.46 455.07 1.14 520 0 M 520 0 C 519.59 11.83 519.31 21.64 520 40 M 520 0 C 520.15 16.15 518.82 32.33 520 40 M 520 40 C 486.73 41.04 452.99 38.45 400 40 M 520 40 C 481.97 39.44 445.24 39.32 400 40 M 400 40 C 398.09 24.43 401.06 7.06 400 0 M 400 40 C 400.1 29.45 399.58 17.63 400 0" fill="none" stroke="#666666" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 401px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #333333; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Journal
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="460" y="24" fill="#333333" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Journal
+                </text>
+            </switch>
+        </g>
+        <path d="M 430 160 L 430 200 L 380 200 L 380 233.63" fill="none" stroke="none" pointer-events="stroke"/>
+        <path d="M 380 238.88 L 376.5 231.88 L 380 233.63 L 383.5 231.88 Z" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 430 160 M 430 160 C 430.13 166.87 429.22 176.71 430 200 M 430 160 C 430.14 175.54 429.73 189.94 430 200 M 430 200 C 416.16 199.91 399.86 198.07 380 200 M 430 200 C 413.76 199.58 399.31 200.45 380 200 M 380 200 C 380.19 214.66 378.79 225.32 380 233.63 M 380 200 C 380.76 211.37 380.44 223.52 380 233.63" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 376.43 231.96 C 376.43 231.96 376.43 231.96 376.43 231.96 M 376.43 231.96 C 376.43 231.96 376.43 231.96 376.43 231.96 M 378.14 236.09 C 378.89 235.46 379.27 234.5 380.11 233.83 M 378.14 236.09 C 378.66 235.31 379.46 234.73 380.11 233.83" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 380 238.88 M 380 238.88 C 378.83 236.63 376.89 232.81 376.5 231.88 M 380 238.88 C 379.11 236.36 377.77 234.14 376.5 231.88 M 376.5 231.88 C 377.55 232.44 379.17 233.35 380 233.63 M 376.5 231.88 C 377.22 232.25 378.18 232.8 380 233.63 M 380 233.63 C 381.18 233.19 381.97 232.43 383.5 231.88 M 380 233.63 C 381.01 233.1 381.87 232.61 383.5 231.88 M 383.5 231.88 C 383.12 233.42 380.84 235.94 380 238.88 M 383.5 231.88 C 382.25 234.24 381.14 236.46 380 238.88" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 490 160 L 490 200 L 540 200 L 540 233.63" fill="none" stroke="none" pointer-events="stroke"/>
+        <path d="M 540 238.88 L 536.5 231.88 L 540 233.63 L 543.5 231.88 Z" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 490 160 M 490 160 C 489.06 169.83 490.97 175.88 490 200 M 490 160 C 489.39 170.63 490.55 179.13 490 200 M 490 200 C 507.39 197.91 521.55 198.74 540 200 M 490 200 C 505.17 199 519.78 199.65 540 200 M 540 200 C 539.54 210.49 540.12 225.36 540 233.63 M 540 200 C 539.77 212.89 540.47 225.3 540 233.63" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 536.45 231.94 C 536.45 231.94 536.45 231.94 536.45 231.94 M 536.45 231.94 C 536.45 231.94 536.45 231.94 536.45 231.94 M 538.16 236.07 C 538.94 235.05 539.22 234.42 540.13 233.81 M 538.16 236.07 C 538.85 235.3 539.44 234.74 540.13 233.81" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 540 238.88 M 540 238.88 C 538.73 235.79 537.71 234.38 536.5 231.88 M 540 238.88 C 538.72 236.14 537.64 233.2 536.5 231.88 M 536.5 231.88 C 537.82 232.33 538.56 232.7 540 233.63 M 536.5 231.88 C 537.16 232.15 537.98 232.58 540 233.63 M 540 233.63 C 540.98 232.63 542.2 232.08 543.5 231.88 M 540 233.63 C 541.13 232.84 542.35 232.35 543.5 231.88 M 543.5 231.88 C 541.82 234.88 541.23 237.46 540 238.88 M 543.5 231.88 C 542.97 233.99 541.59 236.1 540 238.88" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="400" y="120" width="120" height="40" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 400.03 119.97 C 400.03 119.97 400.03 119.97 400.03 119.97 M 400.03 119.97 C 400.03 119.97 400.03 119.97 400.03 119.97 M 399.76 126.37 C 400.26 125.46 401.94 123.97 405.01 120.33 M 399.76 126.37 C 401.32 124.53 403.4 122.07 405.01 120.33 M 400.16 132.01 C 403.74 127.63 408.39 125.39 410.66 119.94 M 400.16 132.01 C 402.27 128.92 404.26 127.72 410.66 119.94 M 399.9 138.41 C 403.88 132.98 410.31 126.5 415.64 120.3 M 399.9 138.41 C 406.81 131.04 412.77 125.01 415.64 120.3 M 400.29 144.05 C 407.62 135.51 412.57 128.75 421.29 119.9 M 400.29 144.05 C 404.65 137.46 409.46 133.31 421.29 119.9 M 400.03 150.45 C 408.24 139.48 418.88 130.12 426.27 120.26 M 400.03 150.45 C 407.9 140.45 417.37 130.14 426.27 120.26 M 399.77 156.85 C 408.24 143.29 422.45 134.05 431.92 119.87 M 399.77 156.85 C 412.05 144.09 423.31 130.26 431.92 119.87 M 401.48 160.98 C 412.64 149.55 421.86 136.77 436.9 120.23 M 401.48 160.98 C 407.78 152.31 415.84 144.12 436.9 120.23 M 406.46 161.34 C 416.26 153 424.88 139.71 442.55 119.83 M 406.46 161.34 C 414.32 152.75 423.71 143.31 442.55 119.83 M 412.11 160.95 C 424.97 148.2 439.01 129.92 447.53 120.19 M 412.11 160.95 C 419.78 152.26 427.16 144.77 447.53 120.19 M 417.09 161.31 C 430.92 145.49 443.61 131.31 453.18 119.8 M 417.09 161.31 C 425.73 153.19 432.15 143.51 453.18 119.8 M 422.74 160.91 C 435.37 146.06 448.58 131.54 458.16 120.16 M 422.74 160.91 C 431.17 152.45 438.97 142.44 458.16 120.16 M 427.72 161.27 C 439.26 145.81 455.64 128.65 463.81 119.76 M 427.72 161.27 C 436.59 152.64 445.23 142.5 463.81 119.76 M 433.37 160.88 C 446.23 149.79 455.71 136.6 468.79 120.12 M 433.37 160.88 C 443.54 149.39 454.91 135.92 468.79 120.12 M 438.35 161.24 C 447.21 150.68 456.9 141.36 474.44 119.73 M 438.35 161.24 C 451.43 145.95 465.16 131.73 474.44 119.73 M 444 160.84 C 454.46 145.96 466.06 133.09 479.42 120.09 M 444 160.84 C 457.39 146.07 471.11 129.26 479.42 120.09 M 448.98 161.2 C 456.05 153.34 464.72 140.54 485.07 119.69 M 448.98 161.2 C 462.12 147.55 473.72 131.39 485.07 119.69 M 454.63 160.81 C 466.88 145.32 478.97 130.65 490.05 120.05 M 454.63 160.81 C 468.26 146.3 480.28 130.15 490.05 120.05 M 459.61 161.17 C 467.27 152.81 476.34 140.73 495.7 119.66 M 459.61 161.17 C 471.91 147.54 482.08 133.57 495.7 119.66 M 464.6 161.53 C 476.44 148.67 487.02 137.96 500.68 120.02 M 464.6 161.53 C 475.67 148.73 486 135.52 500.68 120.02 M 470.24 161.13 C 484.03 143.18 496.74 128.47 506.33 119.62 M 470.24 161.13 C 481.77 147.13 492.62 134.33 506.33 119.62 M 475.23 161.49 C 491.08 146.09 502.35 130.57 511.31 119.99 M 475.23 161.49 C 487.36 147.23 498.1 132.88 511.31 119.99 M 480.87 161.1 C 488.82 150.53 495.31 144.71 516.3 120.35 M 480.87 161.1 C 490.94 147.48 503.32 136.79 516.3 120.35 M 485.86 161.46 C 494.26 149.2 506.34 139.16 521.29 120.71 M 485.86 161.46 C 497.39 147.49 509.56 134.07 521.29 120.71 M 491.5 161.06 C 501.57 146.57 515.15 133.66 521.03 127.1 M 491.5 161.06 C 497.93 154.69 504.42 148.44 521.03 127.1 M 496.49 161.43 C 505.47 150.24 516.16 139.73 520.77 133.5 M 496.49 161.43 C 504.65 150.96 513.47 141.28 520.77 133.5 M 502.13 161.03 C 506.46 152.51 515.18 147.58 521.16 139.14 M 502.13 161.03 C 506.17 155.44 511.17 151.43 521.16 139.14 M 507.12 161.39 C 510.28 156.78 512.4 153.03 520.9 145.54 M 507.12 161.39 C 512.26 157.48 514.82 152.5 520.9 145.54 M 512.76 161 C 515.83 156.29 520.22 153.82 521.29 151.18 M 512.76 161 C 516.16 158.12 518.98 154.43 521.29 151.18 M 517.75 161.36 C 518.55 160.06 519.55 159.58 521.03 157.58 M 517.75 161.36 C 518.95 160.07 519.66 158.84 521.03 157.58" fill="none" stroke="#d5e8d4" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 400 120 C 422.06 118.94 447.23 119.68 520 120 M 400 120 C 429.18 121.33 459.22 119.66 520 120 M 520 120 C 518.39 134.56 518.69 148.59 520 160 M 520 120 C 520.04 132.49 519.4 145.05 520 160 M 520 160 C 474.76 161.08 432.8 158.99 400 160 M 520 160 C 490.97 160.58 462.58 159.13 400 160 M 400 160 C 401.63 151.48 398.2 142.65 400 120 M 400 160 C 399.71 147.02 399.69 134.54 400 120" fill="none" stroke="#82b366" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 140px; margin-left: 401px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Remote Journal
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="460" y="144" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Remote Journal
+                </text>
+            </switch>
+        </g>
+        <rect x="320" y="240" width="120" height="40" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 319.7 239.46 L 439.62 239.57 L 441.06 280.85 L 319.31 278.7" fill="#ffffff" stroke="none" pointer-events="all"/>
+        <path d="M 320 240 C 344.91 242.86 368.91 239.8 440 240 M 320 240 C 359.01 238.82 397.27 240.37 440 240 M 440 240 C 438.53 254.14 441.68 272.24 440 280 M 440 240 C 439.34 251.27 439.6 264.62 440 280 M 440 280 C 398.76 278.42 359.41 281.83 320 280 M 440 280 C 407.3 280.96 373.02 280.4 320 280 M 320 280 C 320.42 265.84 321.51 253.18 320 240 M 320 280 C 320.78 268.88 320.93 258.18 320 240" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 260px; margin-left: 321px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Journal Service
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="380" y="264" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Journal Service
+                </text>
+            </switch>
+        </g>
+        <rect x="480" y="240" width="120" height="40" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 481.22 241.69 L 599.73 241.28 L 598.89 279.38 L 478.9 280.68" fill="#ffffff" stroke="none" pointer-events="all"/>
+        <path d="M 480 240 C 503.77 240.38 526.59 237.52 600 240 M 480 240 C 526.85 238.31 573.32 239.08 600 240 M 600 240 C 601.86 249.72 599.87 255.89 600 280 M 600 240 C 600.64 250.05 599.8 262.19 600 280 M 600 280 C 566.77 279.77 530.01 280.68 480 280 M 600 280 C 561.63 279.34 523.47 279.66 480 280 M 480 280 C 479.2 268.19 480.82 255.71 480 240 M 480 280 C 479.05 270.73 479.37 261.82 480 240" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 260px; margin-left: 481px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Journal Service
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="540" y="264" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Journal Service
+                </text>
+            </switch>
+        </g>
+        <path d="M 750 160 L 750 200 L 700 200 L 700 233.63" fill="none" stroke="none" pointer-events="stroke"/>
+        <path d="M 700 238.88 L 696.5 231.88 L 700 233.63 L 703.5 231.88 Z" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 750 160 M 750 160 C 751.82 167.04 751.83 177.48 750 200 M 750 160 C 750.09 168.68 749.92 179.33 750 200 M 750 200 C 735.19 198.44 720.28 201.92 700 200 M 750 200 C 732.44 200.44 715.04 200.28 700 200 M 700 200 C 698.7 209.8 698.79 220.07 700 233.63 M 700 200 C 699.28 210.6 700.5 219.18 700 233.63" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 696.47 231.91 C 696.47 231.91 696.47 231.91 696.47 231.91 M 696.47 231.91 C 696.47 231.91 696.47 231.91 696.47 231.91 M 698.18 236.05 C 698.88 235.07 699.54 234.9 700.15 233.78 M 698.18 236.05 C 698.79 235.29 699.46 234.48 700.15 233.78" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 700 238.88 M 700 238.88 C 698.23 236.45 697.17 234.19 696.5 231.88 M 700 238.88 C 698.76 237.27 698.24 234.85 696.5 231.88 M 696.5 231.88 C 697.35 232.07 697.66 233 700 233.63 M 696.5 231.88 C 697.6 232.44 698.83 233.21 700 233.63 M 700 233.63 C 700.87 232.89 701.26 233.12 703.5 231.88 M 700 233.63 C 701.28 232.9 702.35 232.46 703.5 231.88 M 703.5 231.88 C 702.83 234.14 700.82 236.54 700 238.88 M 703.5 231.88 C 702.45 233.97 701.91 235.96 700 238.88" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 810 160 L 810 200 L 860 200 L 860 233.63" fill="none" stroke="none" pointer-events="stroke"/>
+        <path d="M 860 238.88 L 856.5 231.88 L 860 233.63 L 863.5 231.88 Z" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 810 160 M 810 160 C 810.74 170.01 809.58 176.64 810 200 M 810 160 C 809.34 171.78 810.74 184.53 810 200 M 810 200 C 827.22 200.33 843.58 198.48 860 200 M 810 200 C 826.99 199.49 841.81 199.1 860 200 M 860 200 C 862.06 209.63 860.12 220.11 860 233.63 M 860 200 C 860.28 210.12 860.53 222.96 860 233.63" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 856.49 231.89 C 856.49 231.89 856.49 231.89 856.49 231.89 M 856.49 231.89 C 856.49 231.89 856.49 231.89 856.49 231.89 M 858.2 236.02 C 858.88 235.3 859.45 234.25 860.17 233.76 M 858.2 236.02 C 858.99 235.28 859.44 234.49 860.17 233.76" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 860 238.88 M 860 238.88 C 859.7 237.17 857.98 235.77 856.5 231.88 M 860 238.88 C 859.16 236.26 858.1 234.68 856.5 231.88 M 856.5 231.88 C 857.58 232.31 859.27 233.05 860 233.63 M 856.5 231.88 C 857.57 232.33 858.66 232.98 860 233.63 M 860 233.63 C 860.71 233.11 862.31 232.78 863.5 231.88 M 860 233.63 C 860.7 233.37 861.83 232.9 863.5 231.88 M 863.5 231.88 C 861.68 234.03 861.34 236.5 860 238.88 M 863.5 231.88 C 863.03 233.73 861.44 235.6 860 238.88" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="720" y="120" width="120" height="40" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 720.07 119.92 C 720.07 119.92 720.07 119.92 720.07 119.92 M 720.07 119.92 C 720.07 119.92 720.07 119.92 720.07 119.92 M 719.8 126.32 C 721.87 124.89 722.8 121.91 725.05 120.28 M 719.8 126.32 C 721.04 125.39 722.37 123.56 725.05 120.28 M 720.2 131.96 C 722.52 130.19 724.27 124.92 730.7 119.89 M 720.2 131.96 C 723.83 127.93 728.43 122.7 730.7 119.89 M 719.94 138.36 C 724.28 133.47 730.9 127.99 735.68 120.25 M 719.94 138.36 C 723.45 133.04 728.4 129.69 735.68 120.25 M 719.68 144.76 C 725.37 138.17 734.77 125.88 741.33 119.85 M 719.68 144.76 C 725.98 137.35 732.76 131.05 741.33 119.85 M 720.07 150.4 C 728.69 140.06 733.9 132.17 746.31 120.21 M 720.07 150.4 C 726.17 144.28 731.75 136.64 746.31 120.21 M 719.81 156.8 C 727.88 144.14 739.45 134.92 751.96 119.82 M 719.81 156.8 C 731.64 143.27 743.44 129.55 751.96 119.82 M 721.52 160.93 C 732.18 148.38 745.99 132.32 756.94 120.18 M 721.52 160.93 C 734.23 146.05 748.98 129.25 756.94 120.18 M 726.5 161.29 C 732.84 153.72 741.25 142.89 762.59 119.79 M 726.5 161.29 C 737.04 147.76 748.11 135.47 762.59 119.79 M 732.15 160.9 C 739.3 151.29 749.62 138.52 767.57 120.15 M 732.15 160.9 C 744.59 146.13 756.62 132.95 767.57 120.15 M 737.13 161.26 C 745.23 150.08 758.44 136.56 773.22 119.75 M 737.13 161.26 C 747.65 151.41 756.7 141.02 773.22 119.75 M 742.78 160.87 C 755.35 146.94 769.19 129.83 778.2 120.11 M 742.78 160.87 C 751.69 150.26 762.78 139.66 778.2 120.11 M 747.76 161.23 C 760.97 147.74 771.84 136.2 783.85 119.72 M 747.76 161.23 C 760.24 146.65 772.07 132.64 783.85 119.72 M 753.41 160.83 C 763.43 149.09 774.11 137.96 788.83 120.08 M 753.41 160.83 C 762.37 149.93 769.73 139.97 788.83 120.08 M 758.39 161.19 C 764.64 153.9 772.03 145.58 794.48 119.68 M 758.39 161.19 C 767.42 151.46 774.74 141.26 794.48 119.68 M 764.04 160.8 C 778.55 145.37 788.29 133.4 799.46 120.04 M 764.04 160.8 C 774.09 148.93 786.13 135.3 799.46 120.04 M 769.02 161.16 C 782.19 146.31 791.66 131.81 805.11 119.65 M 769.02 161.16 C 779.93 147.96 791.98 135.29 805.11 119.65 M 774.01 161.52 C 787.42 147.01 797.39 131.98 810.09 120.01 M 774.01 161.52 C 782.07 152.47 789.25 143.05 810.09 120.01 M 779.65 161.12 C 792.59 149.16 801.55 135.29 815.08 120.37 M 779.65 161.12 C 790.76 147.02 803.19 133.69 815.08 120.37 M 784.64 161.48 C 798.2 147.31 808.3 133.53 820.72 119.97 M 784.64 161.48 C 794.85 149.69 804.33 139.07 820.72 119.97 M 790.28 161.09 C 800.7 148.45 807.78 138.22 825.71 120.33 M 790.28 161.09 C 802.9 145.66 816.59 130.78 825.71 120.33 M 795.27 161.45 C 802.33 151.29 811.76 142.72 831.35 119.94 M 795.27 161.45 C 807.46 147.28 819.07 135.22 831.35 119.94 M 800.91 161.05 C 812.68 150.87 819.21 137.87 836.34 120.3 M 800.91 161.05 C 807.77 153.27 814.83 144.74 836.34 120.3 M 805.9 161.41 C 812.7 149.48 824.24 143 841.33 120.66 M 805.9 161.41 C 819.16 147.6 831.91 131.83 841.33 120.66 M 811.54 161.02 C 816.66 154.54 825.63 145.88 841.07 127.06 M 811.54 161.02 C 818.02 153.38 823.87 147.15 841.07 127.06 M 816.53 161.38 C 824.06 152.16 832.38 143.62 840.81 133.45 M 816.53 161.38 C 823.48 153.11 829.07 146.48 840.81 133.45 M 822.17 160.98 C 826.87 152.46 835.03 146.29 841.2 139.1 M 822.17 160.98 C 826.68 155.15 832.29 149.31 841.2 139.1 M 827.16 161.34 C 830.65 155.39 837.29 152.2 840.94 145.5 M 827.16 161.34 C 831.93 156.04 836.99 151.87 840.94 145.5 M 832.8 160.95 C 837 158.37 840.12 153.47 841.33 151.14 M 832.8 160.95 C 836.67 157.74 839.18 153.79 841.33 151.14 M 837.79 161.31 C 838.34 160.44 839.99 159.06 841.07 157.54 M 837.79 161.31 C 838.79 160.35 840.05 159.11 841.07 157.54" fill="none" stroke="#e1d5e7" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 720 120 C 745.49 117.82 769.96 119.36 840 120 M 720 120 C 760.52 119.69 801.42 120.89 840 120 M 840 120 C 841.32 132.87 841.06 143.19 840 160 M 840 120 C 839.23 129.61 840.19 137.33 840 160 M 840 160 C 814.79 162.46 787.22 162.37 720 160 M 840 160 C 816.3 160.11 792.37 160.2 720 160 M 720 160 C 719.96 144.89 718.65 128.78 720 120 M 720 160 C 720.39 146.45 719.04 133.09 720 120" fill="none" stroke="#9673a6" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 140px; margin-left: 721px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                External Journal
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="780" y="144" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    External Journal
+                </text>
+            </switch>
+        </g>
+        <rect x="640" y="240" width="120" height="40" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 639.34 240.71 L 760.04 239.29 L 761.71 279.87 L 638.19 279.34" fill="#ffffff" stroke="none" pointer-events="all"/>
+        <path d="M 640 240 C 666.53 239.52 692.39 239.32 760 240 M 640 240 C 664.96 240.9 687.98 240.5 760 240 M 760 240 C 760.03 247.49 759.76 257.02 760 280 M 760 240 C 759.43 251.87 759.5 264.96 760 280 M 760 280 C 724.75 279.12 686.98 280.45 640 280 M 760 280 C 734.63 281.15 707.89 280.57 640 280 M 640 280 C 638.48 269.36 639.69 257.75 640 240 M 640 280 C 640.39 270.44 641.34 260.38 640 240" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 260px; margin-left: 641px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Kafka
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="700" y="264" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Kafka
+                </text>
+            </switch>
+        </g>
+        <rect x="800" y="240" width="120" height="40" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 800.87 238.93 L 920.15 241 L 919.54 278.4 L 801.78 281.33" fill="#ffffff" stroke="none" pointer-events="all"/>
+        <path d="M 800 240 C 825.38 241.04 850.07 241.04 920 240 M 800 240 C 832.79 240.39 866.03 239.21 920 240 M 920 240 C 919.36 251.07 917.96 260.67 920 280 M 920 240 C 920.73 250.65 919.69 262.54 920 280 M 920 280 C 888.76 280.47 857.58 279.29 800 280 M 920 280 C 888.96 281.53 858.34 279.84 800 280 M 800 280 C 800.46 263.71 798.21 248.28 800 240 M 800 280 C 800.66 264.29 799.78 248.02 800 240" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 260px; margin-left: 801px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                LogDevice
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="860" y="264" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    LogDevice
+                </text>
+            </switch>
+        </g>
+        <path d="M 110 160 L 110 200 L 60 200 L 60 233.63" fill="none" stroke="none" pointer-events="stroke"/>
+        <path d="M 60 238.88 L 56.5 231.88 L 60 233.63 L 63.5 231.88 Z" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 110 160 M 110 160 C 111.21 167.9 111.47 177.55 110 200 M 110 160 C 108.89 172.44 108.9 184.75 110 200 M 110 200 C 98.29 198.02 84.89 201.51 60 200 M 110 200 C 93.3 199.54 76.71 200.63 60 200 M 60 200 C 60.83 208.1 61.46 215.83 60 233.63 M 60 200 C 59.76 209.86 60.41 219.75 60 233.63" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 56.39 232.01 C 56.39 232.01 56.39 232.01 56.39 232.01 M 56.39 232.01 C 56.39 232.01 56.39 232.01 56.39 232.01 M 58.75 235.38 C 59.23 234.79 59.55 234.74 60.07 233.88 M 58.75 235.38 C 59.21 234.86 59.69 234.45 60.07 233.88" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 60 238.88 M 60 238.88 C 59.63 237.32 59.05 235.6 56.5 231.88 M 60 238.88 C 58.71 236.58 57.9 234.31 56.5 231.88 M 56.5 231.88 C 57.35 232.21 58.39 232.51 60 233.63 M 56.5 231.88 C 57.64 232.36 58.74 233.03 60 233.63 M 60 233.63 C 60.56 232.97 61.71 232.78 63.5 231.88 M 60 233.63 C 61.19 232.94 62.39 232.49 63.5 231.88 M 63.5 231.88 C 62.84 233.59 62.02 234.49 60 238.88 M 63.5 231.88 C 62.46 234.48 60.82 236.82 60 238.88" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 170 160 L 170 200 L 220 200 L 220 233.63" fill="none" stroke="none" pointer-events="stroke"/>
+        <path d="M 220 238.88 L 216.5 231.88 L 220 233.63 L 223.5 231.88 Z" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 170 160 M 170 160 C 168.59 167.93 169.07 174.97 170 200 M 170 160 C 169.85 169.96 170.4 178.91 170 200 M 170 200 C 179.99 200.24 191.58 199.72 220 200 M 170 200 C 182.97 199.48 197.12 200.66 220 200 M 220 200 C 220.77 212.03 218.78 225.64 220 233.63 M 220 200 C 218.97 206.42 219.26 215.06 220 233.63" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 216.41 231.98 C 216.41 231.98 216.41 231.98 216.41 231.98 M 216.41 231.98 C 216.41 231.98 216.41 231.98 216.41 231.98 M 218.12 236.12 C 218.42 235.72 218.99 235.16 220.09 233.85 M 218.12 236.12 C 218.57 235.43 219.2 234.99 220.09 233.85" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 220 238.88 M 220 238.88 C 218.8 235.57 216.64 232.92 216.5 231.88 M 220 238.88 C 218.93 237.14 218.31 236.3 216.5 231.88 M 216.5 231.88 C 217.34 232.08 218.04 232.54 220 233.63 M 216.5 231.88 C 217.79 232.47 219.3 233.24 220 233.63 M 220 233.63 C 221.21 233.12 222.18 232.78 223.5 231.88 M 220 233.63 C 220.65 233.27 221.79 232.76 223.5 231.88 M 223.5 231.88 C 222.92 233.93 220.39 236.67 220 238.88 M 223.5 231.88 C 221.92 234.64 220.67 236.9 220 238.88" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="80" y="120" width="120" height="40" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 79.99 120.02 C 79.99 120.02 79.99 120.02 79.99 120.02 M 79.99 120.02 C 79.99 120.02 79.99 120.02 79.99 120.02 M 79.72 126.41 C 82.08 124.61 83.57 121.12 84.97 120.38 M 79.72 126.41 C 81.65 124.65 83.34 122.68 84.97 120.38 M 80.12 132.06 C 85 128.62 86.65 122.64 90.62 119.98 M 80.12 132.06 C 83.09 128.26 85.68 124.52 90.62 119.98 M 79.86 138.45 C 83.84 132.84 85.87 130.87 95.6 120.34 M 79.86 138.45 C 82.9 134.78 87.06 129.84 95.6 120.34 M 80.25 144.1 C 85.31 136.45 88.91 133.91 101.25 119.95 M 80.25 144.1 C 87.05 137.35 91.88 129.09 101.25 119.95 M 79.99 150.5 C 86.95 145.13 90.91 139.05 106.23 120.31 M 79.99 150.5 C 89.92 139.53 98.28 130.5 106.23 120.31 M 79.73 156.89 C 85.72 149.7 91.36 140.32 111.88 119.91 M 79.73 156.89 C 87.5 147.52 93.86 138.98 111.88 119.91 M 81.44 161.03 C 90.22 151.53 98.95 138.83 116.86 120.27 M 81.44 161.03 C 94.4 147.2 106.86 131.65 116.86 120.27 M 86.42 161.39 C 95.71 150.73 105.52 140.75 122.51 119.88 M 86.42 161.39 C 98.59 148.83 109.14 134.3 122.51 119.88 M 92.07 160.99 C 102.26 150.4 111.68 135.73 127.49 120.24 M 92.07 160.99 C 98.82 153.11 105.23 143.98 127.49 120.24 M 97.05 161.35 C 107.75 147.9 120.44 138.49 133.14 119.84 M 97.05 161.35 C 105.3 152.53 112.32 142.47 133.14 119.84 M 102.7 160.96 C 112.73 147.3 123.94 137.37 138.12 120.2 M 102.7 160.96 C 115.85 145.51 128.25 130.85 138.12 120.2 M 107.68 161.32 C 120.03 145.85 132.44 131.66 143.77 119.81 M 107.68 161.32 C 117.65 150.09 126.8 139.94 143.77 119.81 M 113.33 160.92 C 125.59 147.46 140.42 131.32 148.75 120.17 M 113.33 160.92 C 120.94 150.35 130.3 140.6 148.75 120.17 M 118.31 161.28 C 129.46 146.07 145.66 130.26 154.4 119.77 M 118.31 161.28 C 126.78 152.76 133.45 143.71 154.4 119.77 M 123.96 160.89 C 134.48 149.75 142.75 137.11 159.38 120.13 M 123.96 160.89 C 131.3 150.67 140.28 140.84 159.38 120.13 M 128.94 161.25 C 140.46 150.47 149.57 138.83 165.03 119.74 M 128.94 161.25 C 138.68 149.81 149.35 136.97 165.03 119.74 M 134.59 160.85 C 144.74 147.4 155.83 138.44 170.01 120.1 M 134.59 160.85 C 143.92 150.61 152.05 139.46 170.01 120.1 M 139.57 161.21 C 148.11 152.37 153.49 143.2 175.66 119.71 M 139.57 161.21 C 155.12 144.17 167.84 128.01 175.66 119.71 M 145.22 160.82 C 153.1 152.13 160.17 143.93 180.64 120.07 M 145.22 160.82 C 151.69 153.43 158.67 144.43 180.64 120.07 M 150.2 161.18 C 163.98 144.82 177.07 131 186.29 119.67 M 150.2 161.18 C 159.08 150.14 169.14 139.55 186.29 119.67 M 155.85 160.79 C 164.73 147.92 176.32 136.27 191.27 120.03 M 155.85 160.79 C 165.57 148.06 176.83 137.94 191.27 120.03 M 160.83 161.15 C 170.99 150.21 183.54 134.27 196.92 119.64 M 160.83 161.15 C 170.88 151.76 179.43 139.96 196.92 119.64 M 165.82 161.51 C 175.65 147.39 187.79 137.26 201.25 120.75 M 165.82 161.51 C 177.24 147.72 189.1 135.74 201.25 120.75 M 171.46 161.11 C 179.34 151.84 188.16 141.2 200.99 127.15 M 171.46 161.11 C 176.74 152.72 184.59 146.57 200.99 127.15 M 176.45 161.47 C 183.38 153.25 192.85 144.55 201.38 132.79 M 176.45 161.47 C 182.25 154.59 187.93 147.98 201.38 132.79 M 182.09 161.08 C 189.74 152.11 194.29 147.35 201.12 139.19 M 182.09 161.08 C 186.96 155.89 192.05 148.92 201.12 139.19 M 187.08 161.44 C 191.38 158.57 196.98 152.35 200.86 145.59 M 187.08 161.44 C 192.24 156.89 196.27 152.22 200.86 145.59 M 192.72 161.04 C 195.15 158.02 200.2 153.46 201.25 151.23 M 192.72 161.04 C 194.79 157.56 197.98 154.54 201.25 151.23 M 197.71 161.4 C 198.57 160.36 199.31 158.77 200.99 157.63 M 197.71 161.4 C 198.63 160.83 199.11 159.75 200.99 157.63" fill="none" stroke="#dae8fc" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 80 120 C 104.24 120.96 131.75 121.16 200 120 M 80 120 C 120.63 120.28 162.08 120.32 200 120 M 200 120 C 199.49 130.65 200.95 144.32 200 160 M 200 120 C 200.02 131.43 199.89 140.11 200 160 M 200 160 C 172.77 157.81 144.19 158.14 80 160 M 200 160 C 163.3 161.91 128.79 161.1 80 160 M 80 160 C 79.25 146.06 81.52 134.81 80 120 M 80 160 C 78.93 146.15 80.22 131.65 80 120" fill="none" stroke="#6c8ebf" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 140px; margin-left: 81px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Local Journal
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="140" y="144" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Local Journal
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="240" width="120" height="40" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M -0.08 239.39 L 120.37 240.43 L 119.18 279.45 L 0.96 281.3" fill="#ffffff" stroke="none" pointer-events="all"/>
+        <path d="M 0 240 C 27.1 238.48 49.43 238.88 120 240 M 0 240 C 26.46 239.77 52.13 241.03 120 240 M 120 240 C 118.83 254.23 119.14 263.97 120 280 M 120 240 C 119.32 250.21 120.09 259.68 120 280 M 120 280 C 72.78 279.16 26.79 280.98 0 280 M 120 280 C 79.63 277.89 37.24 277.97 0 280 M 0 280 C 2.03 268.41 0.83 257.34 0 240 M 0 280 C 0 268.01 -0.55 255.29 0 240" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 260px; margin-left: 1px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                Memory
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="60" y="264" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Memory
+                </text>
+            </switch>
+        </g>
+        <rect x="160" y="240" width="120" height="40" fill="none" stroke="none" pointer-events="all"/>
+        <path d="M 161.7 238.26 L 279.77 239.8 L 281.91 279.28 L 160.72 280.84" fill="#ffffff" stroke="none" pointer-events="all"/>
+        <path d="M 160 240 C 184.83 241.71 211.87 240.08 280 240 M 160 240 C 205.53 240.06 249.64 239.86 280 240 M 280 240 C 279.62 253.57 281.76 269.46 280 280 M 280 240 C 279.87 251.6 279.54 262.84 280 280 M 280 280 C 253.05 282.74 224.94 281.53 160 280 M 280 280 C 235.62 278.11 190.66 278.82 160 280 M 160 280 C 161.47 266.94 160.19 257.29 160 240 M 160 280 C 160.51 269.73 158.96 260.41 160 240" fill="none" stroke="#000000" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 260px; margin-left: 161px;">
+                        <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                File System
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="220" y="264" fill="#000000" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    File System
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Viewer does not support full SVG 1.1
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -30,6 +30,7 @@ It is also possible to support stream subscriptions. We leave the exploration of
 
 Released records can be garbage collected or archived.
 Whether released records are readable depends on the implementation.
+For example, if records are archived, it should allow users to recover data from archives.
 Nevertheless, implementations should guarantee to return continuous records. That is, the returned records must be a sub-sequence of a stream.
 
 ## Guidelines
@@ -49,6 +50,6 @@ Users can choose an appropriate implementation for their applications.
 ## Discussions
 
 Casual discussions about the design and implementation should be proceeded in [this discussion][journal-discussion].
-Formal discussions about the design of a specific implementation should be proceeded with an RFC document.
+Formal discussions about the design of a specific implementation should be proceeded with an RFC.
 
 [journal-discussion]: https://github.com/engula/engula/discussions/70

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -9,38 +9,44 @@ Journal can be used as a standalone component or integrated with Engula.
 
 Journal divides logs into streams.
 A stream stores a sequence of records.
-Each stream has a unique identifier called stream id.
+Each stream has a unique identifier called the stream name.
 Each record within a stream is associated with a unique sequence number.
 Users should assign an increasing sequence number to records when appending to a stream.
 However, sequence numbers within a stream are not required to be continuous, which allows users to dispatch records to multiple streams.
 
-Journal provides the following interfaces to manipulate a stream:
+Journal provides the following interfaces to manipulate streams:
 
-- Read records since a sequence number
+- List streams
+- Create a stream with a unique name
+- Delete a stream
+
+Journal provides the following interfaces to manipulate records of a stream:
+
 - Append records with a sequence number
 - Release records up to a sequence number
+- Read records started with a sequence number
 
 Released records can be garbage collected or archived.
 Whether released records are readable depends on the implementation.
 Nevertheless, implementations should guarantee to return continuous records. That is, the returned records must be a sub-sequence of the stream.
 
-## Architecture
+## Guidelines
 
 ![Architecture](images/journal-architecture.drawio.svg)
 
 Journal can be implemented in the following forms:
 
 - Local Journal: a module that stores data in memory or file system.
-- Remote Journal: a client that stores data in one or more remote services.
+- Remote Journal: a client that stores data in multiple remote services.
 - External Journal: a client that stores data in various third-party services.
 
-Journal doesn't assume how data should be persisted or replicated.
+Journal doesn't assume how data should be persisted.
 It is up to the implementer to decide what guarantees it provides.
-Users can choose the best-fit implementation for their applications.
+Users can choose an appropriate implementation for their applications.
 
-## Discussions and Implementations
+## Discussions
 
-Casual discussions about the design and implementations should be proceeded in the [forum][journal-discussion].
-Formal discussions about the design of a specific implementation should be submitted as an RFC.
+Casual discussions about the design and implementation should be proceeded in the [forum][journal-discussion].
+Formal discussions about the design of a specific implementation should be proceeded with an RFC document.
 
 [journal-discussion]: https://github.com/engula/engula/discussions/70

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -1,0 +1,42 @@
+# Journal
+
+This document describes the top-level design of Journal.
+
+Journal provides an abstraction to store logs.
+Journal can be used as a standalone component or integrated with Engula.
+
+## Semantics
+
+Journal divides logs into streams.
+A stream is a sequence of records.
+Each stream has a unique identifier called stream id.
+Each record within a stream is associated with a unique sequence number.
+Users should assign an increasing sequence number to records when appending to a stream.
+However, sequence numbers within a stream are not required to be continuous, which allows users to dispatch records to multiple streams.
+
+Journal provides the following interfaces to manipulate a stream:
+
+- Read records since a sequence number
+- Append records with a sequence number
+- Release records up to a sequence number
+
+## Architecture
+
+![Architecture](images/journal-architecture.drawio.svg)
+
+Journal can be implemented in the following forms:
+
+- Local Journal: a module that stores data in memory or file system.
+- Remote Journal: a client that stores data in one or more remote services.
+- External Journal: a client that stores data in various third-party services.
+
+Journal doesn't assume how data should be persisted or replicated.
+It is up to the implementer to decide what guarantees it provides.
+Users can choose the best-fit implementation for their applications.
+
+## Discussions and Implementations
+
+Casual discussions about the design and implementations should be proceeded in the [forum][journal-discussion].
+Formal discussions about the design of a specific implementation should be submitted as an RFC.
+
+[journal-discussion]: https://github.com/engula/engula/discussions/70

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -2,12 +2,12 @@
 
 This document describes the top-level design of Journal.
 
-Journal provides an abstraction to store logs.
+Journal provides an abstraction to store data streams.
 Journal can be used as a standalone component or integrated with Engula.
 
 ## Semantics
 
-Journal divides logs into streams.
+Journal divides data into streams.
 A stream stores a sequence of records.
 Each stream has a unique identifier called the stream name.
 Each record within a stream is associated with a unique sequence number.
@@ -22,13 +22,15 @@ Journal provides the following interfaces to manipulate streams:
 
 Journal provides the following interfaces to manipulate records of a stream:
 
+- Read records since a sequence number
 - Append records with a sequence number
 - Release records up to a sequence number
-- Read records started with a sequence number
+
+It is also possible to support stream subscriptions. We leave the exploration of this feature to future work.
 
 Released records can be garbage collected or archived.
 Whether released records are readable depends on the implementation.
-Nevertheless, implementations should guarantee to return continuous records. That is, the returned records must be a sub-sequence of the stream.
+Nevertheless, implementations should guarantee to return continuous records. That is, the returned records must be a sub-sequence of a stream.
 
 ## Guidelines
 
@@ -46,7 +48,7 @@ Users can choose an appropriate implementation for their applications.
 
 ## Discussions
 
-Casual discussions about the design and implementation should be proceeded in the [forum][journal-discussion].
+Casual discussions about the design and implementation should be proceeded in [this discussion][journal-discussion].
 Formal discussions about the design of a specific implementation should be proceeded with an RFC document.
 
 [journal-discussion]: https://github.com/engula/engula/discussions/70

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -2,17 +2,17 @@
 
 This document describes the top-level design of Journal.
 
-Journal provides an abstraction to store data streams.
+Journal provides an abstraction to store event streams.
 Journal can be used as a standalone component or integrated with Engula.
 
 ## Semantics
 
 Journal divides data into streams.
-A stream stores a sequence of records.
+A stream stores a sequence of events.
 Each stream has a unique identifier called the stream name.
-Each record within a stream is associated with a unique sequence number.
-Users should assign an increasing sequence number to records when appending to a stream.
-However, sequence numbers within a stream are not required to be continuous, which allows users to dispatch records to multiple streams.
+Each event within a stream is associated with a unique timestamp.
+Users should assign an increasing timestamp to events when appending to a stream.
+However, timestamps within a stream are not required to be continuous, which allows users to dispatch events to multiple streams.
 
 Journal provides the following interfaces to manipulate streams:
 
@@ -20,18 +20,18 @@ Journal provides the following interfaces to manipulate streams:
 - Create a stream with a unique name
 - Delete a stream
 
-Journal provides the following interfaces to manipulate records of a stream:
+Journal provides the following interfaces to manipulate events in a stream:
 
-- Read records since a sequence number
-- Append records with a sequence number
-- Release records up to a sequence number
+- Read events since a timestamp
+- Append events with a timestamp
+- Release events up to a timestamp
 
 It is also possible to support stream subscriptions. We leave the exploration of this feature to future work.
 
-Released records can be garbage collected or archived.
-Whether released records are readable depends on the implementation.
-For example, if records are archived, it should allow users to recover data from archives.
-Nevertheless, implementations should guarantee to return continuous records. That is, the returned records must be a sub-sequence of a stream.
+Released events can be garbage collected or archived.
+Whether released events are readable depends on the implementation.
+For example, if events are archived, it should allow users to recover from archives.
+Nevertheless, implementations should guarantee to return continuous events. That is, the returned events must be a sub-sequence of a stream.
 
 ## Guidelines
 
@@ -49,7 +49,7 @@ Users can choose an appropriate implementation for their applications.
 
 ## Discussions
 
-Casual discussions about the design and implementation should be proceeded in [this discussion][journal-discussion].
-Formal discussions about the design of a specific implementation should be proceeded with an RFC.
+Casual discussions about the design and implementation should proceed in [this discussion][journal-discussion].
+Formal discussions about the design of a specific implementation should proceed with an RFC.
 
 [journal-discussion]: https://github.com/engula/engula/discussions/70

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -8,7 +8,7 @@ Journal can be used as a standalone component or integrated with Engula.
 ## Semantics
 
 Journal divides logs into streams.
-A stream is a sequence of records.
+A stream stores a sequence of records.
 Each stream has a unique identifier called stream id.
 Each record within a stream is associated with a unique sequence number.
 Users should assign an increasing sequence number to records when appending to a stream.
@@ -19,6 +19,10 @@ Journal provides the following interfaces to manipulate a stream:
 - Read records since a sequence number
 - Append records with a sequence number
 - Release records up to a sequence number
+
+Released records can be garbage collected or archived.
+Whether released records are readable depends on the implementation.
+Nevertheless, implementations should guarantee to return continuous records. That is, the returned records must be a sub-sequence of the stream.
 
 ## Architecture
 

--- a/docs/microunit.md
+++ b/docs/microunit.md
@@ -2,7 +2,7 @@
 
 This document describes the design of microunit.
 
-Microunit is a lightweight unit orchestration framework for Engula.
+Microunit is a lightweight unit orchestration framework for resource management.
 
 ## Architecture
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -49,7 +49,7 @@ Users can choose an appropriate implementation for their applications.
 
 ## Discussions
 
-Casual discussions about the design and implementation should be proceeded in [this discussion][storage-discussion].
-Formal discussions about the design of a specific implementation should be submitted as an RFC.
+Casual discussions about the design and implementation should proceed in [this discussion][storage-discussion].
+Formal discussions about the design of a specific implementation should proceed with an RFC.
 
 [storage-discussion]: https://github.com/engula/engula/discussions/79


### PR DESCRIPTION
Formalize the top-level journal design.

The architecture looks like this:

![Architecture](https://raw.githubusercontent.com/huachaohuang/engula/d802fde3f469ba5779846bcfa362c04d7c8c26f2/docs/images/journal-architecture.drawio.svg)