### PR TITLE
storage: prototype impl storage traits for aws-s3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,10 +38,136 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "aws-auth"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
+dependencies = [
+ "aws-types",
+ "pin-project",
+ "smithy-async",
+ "smithy-http",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-endpoint"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
+dependencies = [
+ "aws-types",
+ "http",
+ "regex",
+ "smithy-http",
+]
+
+[[package]]
+name = "aws-http"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
+dependencies = [
+ "aws-types",
+ "http",
+ "lazy_static",
+ "smithy-http",
+ "smithy-types",
+ "thiserror",
+]
+
+[[package]]
+name = "aws-hyper"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
+dependencies = [
+ "aws-auth",
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "bytes",
+ "fastrand",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "pin-project",
+ "smithy-client",
+ "smithy-http",
+ "smithy-http-tower",
+ "smithy-types",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "0.0.17-alpha"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
+dependencies = [
+ "aws-auth",
+ "aws-endpoint",
+ "aws-http",
+ "aws-hyper",
+ "aws-sig-auth",
+ "aws-types",
+ "bytes",
+ "http",
+ "md5",
+ "smithy-client",
+ "smithy-eventstream",
+ "smithy-http",
+ "smithy-types",
+ "smithy-xml",
+]
+
+[[package]]
+name = "aws-sig-auth"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
+dependencies = [
+ "aws-auth",
+ "aws-sigv4",
+ "aws-types",
+ "http",
+ "smithy-eventstream",
+ "smithy-http",
+ "thiserror",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
+dependencies = [
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "hex",
+ "http",
+ "http-body",
+ "percent-encoding",
+ "ring",
+ "smithy-eventstream",
+]
+
+[[package]]
+name = "aws-types"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
+dependencies = [
+ "lazy_static",
+ "rustc_version",
+ "smithy-async",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
 name = "axum"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c3f630b925c7a85089ff794fdce495c88c80d38710f31eb9817c8399fd77ce"
+checksum = "97dd56c26513a897c3a106ba73eff3a4be489d46cf0da20e40bd6f5c6f8c8941"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -74,10 +200,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bumpalo"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "bytes"
@@ -86,10 +224,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e314712951c43123e5920a446464929adc667a5eade7f8fb3997776c9df6e54"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "winapi",
+]
 
 [[package]]
 name = "clap"
@@ -123,8 +289,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "ct-logs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct",
+]
+
+[[package]]
 name = "datatypes"
 version = "0.1.0"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "engula"
@@ -133,6 +339,15 @@ dependencies = [
  "clap",
  "microunit",
  "tokio",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -167,6 +382,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+dependencies = [
+ "autocfg",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,9 +414,13 @@ checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg",
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
 ]
 
 [[package]]
@@ -200,6 +432,25 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -225,6 +476,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -270,6 +527,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -281,6 +539,23 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "ct-logs",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
 ]
 
 [[package]]
@@ -309,6 +584,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
+name = "js-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,9 +600,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "lock_api"
@@ -356,6 +640,12 @@ name = "matchit"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58b6f41fdfbec185dd3dff58b51e323f5bc61692c0de38419a957b0dcfccca3c"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -413,6 +703,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +736,12 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "os_str_bytes"
@@ -525,6 +840,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,16 +879,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
@@ -585,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "itoa",
  "ryu",
@@ -616,10 +1056,110 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+
+[[package]]
 name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+
+[[package]]
+name = "smithy-async"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "smithy-client"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
+dependencies = [
+ "bytes",
+ "fastrand",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "pin-project",
+ "smithy-http",
+ "smithy-http-tower",
+ "smithy-types",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "smithy-eventstream"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
+dependencies = [
+ "bytes",
+ "crc32fast",
+ "smithy-types",
+]
+
+[[package]]
+name = "smithy-http"
+version = "0.0.1"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
+dependencies = [
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "percent-encoding",
+ "pin-project",
+ "smithy-eventstream",
+ "smithy-types",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "smithy-http-tower"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project",
+ "smithy-http",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "smithy-types"
+version = "0.0.1"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
+dependencies = [
+ "chrono",
+ "itoa",
+ "num-integer",
+ "ryu",
+]
+
+[[package]]
+name = "smithy-xml"
+version = "0.1.0"
+source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
+dependencies = [
+ "thiserror",
+ "xmlparser",
+]
 
 [[package]]
 name = "socket2"
@@ -632,10 +1172,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "storage"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "aws-sdk-s3",
+ "aws-types",
+ "bytes",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -680,6 +1231,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +1279,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -836,6 +1418,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +1456,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+
+[[package]]
+name = "web-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,3 +1559,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
+
+[[package]]
+name = "zeroize"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -4,5 +4,18 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
+[features]
+
+default = [ "aws-s3" ]
+
+full = [ "aws-s3" ]
+
+aws-s3 = [ "aws-types", "aws-sdk-s3"]
+
 [dependencies]
 async-trait = "0.1"
+aws-types = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.17-alpha", package = "aws-types", optional = true }
+aws-sdk-s3 = { git = "https://github.com/awslabs/aws-sdk-rust", tag = "v0.0.17-alpha", package = "aws-sdk-s3", optional = true }
+bytes = "1.1"
+thiserror = "1.0"
+tokio = { version = "1.13.0", features = ["full"] }

--- a/src/storage/src/aws_s3/bucket_handle.rs
+++ b/src/storage/src/aws_s3/bucket_handle.rs
@@ -1,0 +1,122 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use aws_sdk_s3::{
+    model::{Delete, ObjectIdentifier},
+    ByteStream, Client,
+};
+use bytes::Bytes;
+
+use crate::{
+    aws_s3::object_handle::{S3ObjectReader, S3ObjectWriter},
+    bucket_handle::BucketHandle,
+    error::StorageResult,
+    object_handle::{ObjectReader, ObjectWriter},
+    StorageError,
+};
+
+pub struct S3BucketHandle {
+    client: Client,
+    bucket_name: String,
+}
+
+impl S3BucketHandle {
+    pub fn new(client: Client, bucket_name: String) -> Self {
+        S3BucketHandle {
+            client,
+            bucket_name,
+        }
+    }
+}
+
+#[async_trait]
+impl BucketHandle for S3BucketHandle {
+    async fn new_writer(&self, name: &str) -> StorageResult<Box<dyn ObjectWriter>> {
+        let output = self
+            .client
+            .create_multipart_upload()
+            .bucket(self.bucket_name.clone())
+            .key(name.to_string())
+            .send()
+            .await
+            .map_err(|e| {
+                let msg = e.to_string();
+                StorageError { msg }
+            })?;
+
+        let upload_id = output.upload_id.unwrap();
+        Ok(Box::new(S3ObjectWriter::new(
+            self.client.clone(),
+            self.bucket_name.clone(),
+            name.to_string(),
+            upload_id,
+        )))
+    }
+
+    async fn new_reader(&self, name: &str) -> Box<dyn ObjectReader> {
+        Box::new(S3ObjectReader::new(
+            self.client.clone(),
+            self.bucket_name.clone(),
+            name.to_string(),
+        ))
+    }
+
+    async fn delete_object(&self, key: &str) -> StorageResult<()> {
+        self.client
+            .delete_object()
+            .bucket(self.bucket_name.clone())
+            .key(key.to_string())
+            .send()
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                let msg = e.to_string();
+                StorageError { msg }
+            })
+    }
+
+    async fn delete_objects(&self, key: Vec<String>) -> StorageResult<()> {
+        let objs: Vec<ObjectIdentifier> = key
+            .iter()
+            .map(|k| ObjectIdentifier::builder().key(k).build())
+            .collect();
+        self.client
+            .delete_objects()
+            .delete(Delete::builder().set_objects(Some(objs)).build())
+            .bucket(self.bucket_name.clone())
+            .send()
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                let msg = e.to_string();
+                StorageError { msg }
+            })
+    }
+
+    async fn put_object(&self, name: &str, body: Bytes) -> StorageResult<()> {
+        self.client
+            .put_object()
+            .bucket(self.bucket_name.clone())
+            .key(name.to_string())
+            .body(ByteStream::from(body))
+            .send()
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                let msg = e.to_string();
+                StorageError { msg }
+            })
+    }
+}

--- a/src/storage/src/aws_s3/mod.rs
+++ b/src/storage/src/aws_s3/mod.rs
@@ -12,19 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use async_trait::async_trait;
-use bytes::Bytes;
+pub mod bucket_handle;
+pub mod object_handle;
+pub mod storage;
 
-use crate::StorageResult;
-
-#[async_trait]
-pub trait ObjectWriter {
-    async fn write(&mut self, data: Bytes);
-
-    async fn finish(&mut self) -> StorageResult<()>;
-}
-
-#[async_trait]
-pub trait ObjectReader {
-    async fn read_at(&self, offset: i32, size: i32) -> StorageResult<Vec<u8>>;
-}
+pub use storage::RemoteS3Storage;

--- a/src/storage/src/aws_s3/object_handle.rs
+++ b/src/storage/src/aws_s3/object_handle.rs
@@ -1,0 +1,185 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use aws_sdk_s3::{
+    model::{CompletedMultipartUpload, CompletedPart},
+    ByteStream, Client,
+};
+use bytes::{Buf, Bytes};
+use tokio::task::JoinHandle;
+
+use crate::{
+    error::StorageResult,
+    object_handle::{ObjectReader, ObjectWriter},
+    StorageError,
+};
+
+pub struct S3ObjectReader {
+    client: Client,
+    bucket_name: String,
+    key: String,
+}
+
+impl S3ObjectReader {
+    pub fn new(client: Client, bucket_name: String, key: String) -> Self {
+        Self {
+            client,
+            bucket_name,
+            key,
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectReader for S3ObjectReader {
+    async fn read_at(&self, offset: i32, size: i32) -> StorageResult<Vec<u8>> {
+        let range = format!("bytes={}-{}", offset, offset + size - 1);
+        let rs = self
+            .client
+            .get_object()
+            .bucket(self.bucket_name.clone())
+            .key(self.key.clone())
+            .range(range)
+            .send()
+            .await;
+
+        match rs {
+            Ok(output) => match output.body.collect().await {
+                Ok(mut bytes) => {
+                    let mut data = vec![0; bytes.remaining()];
+                    bytes.copy_to_slice(&mut data);
+                    Ok(data)
+                }
+                Err(err) => Err(StorageError {
+                    msg: err.to_string(),
+                }),
+            },
+            Err(err) => Err(StorageError {
+                msg: err.to_string(),
+            }),
+        }
+    }
+}
+
+pub struct S3ObjectWriter {
+    client: Client,
+    bucket_name: String,
+    key: String,
+    upload_id: String,
+    part_handles: Vec<JoinHandle<StorageResult<CompletedPart>>>,
+}
+
+impl S3ObjectWriter {
+    pub fn new(client: Client, bucket_name: String, key: String, upload_id: String) -> Self {
+        Self {
+            client,
+            bucket_name,
+            key,
+            upload_id,
+            part_handles: vec![],
+        }
+    }
+
+    fn upload_part(&mut self, data: Bytes) {
+        let f_cli = self.client.clone();
+        let f_bucket = self.bucket_name.clone();
+        let f_test_key = self.key.clone();
+        let f_upload_id = self.upload_id.clone();
+        let part_number = (self.part_handles.len() + 1) as i32;
+
+        let part_handle = tokio::task::spawn(async move {
+            let r: StorageResult<CompletedPart> = f_cli
+                .clone()
+                .upload_part()
+                .bucket(f_bucket)
+                .key(f_test_key)
+                .upload_id(f_upload_id)
+                .part_number(part_number)
+                .body(ByteStream::from(data))
+                .send()
+                .await
+                .map(|output| {
+                    CompletedPart::builder()
+                        .e_tag(output.e_tag.unwrap())
+                        .part_number(part_number)
+                        .build()
+                })
+                .map_err(|e| {
+                    let msg = e.to_string();
+                    StorageError { msg }
+                });
+            r
+        });
+        self.part_handles.push(part_handle);
+    }
+
+    async fn collect_parts(&mut self) -> StorageResult<Vec<CompletedPart>> {
+        let mut parts = Vec::new();
+        for handle in self.part_handles.split_off(0) {
+            match handle.await {
+                Ok(rpart) => match rpart {
+                    Ok(part) => parts.push(part),
+                    Err(e) => return Err(e),
+                },
+                Err(e) => return Err(StorageError { msg: e.to_string() }),
+            }
+        }
+        Ok(parts)
+    }
+}
+
+const UPLOAD_PART_SIZE: usize = 8 * 1024 * 1024;
+
+#[async_trait]
+impl ObjectWriter for S3ObjectWriter {
+    async fn write(&mut self, data: Bytes) {
+        if data.len() < UPLOAD_PART_SIZE * 2 {
+            self.upload_part(data);
+            return;
+        }
+
+        let mut offset = 0;
+        while offset < data.len() {
+            let end = if data.len() - offset < UPLOAD_PART_SIZE * 2 {
+                data.len()
+            } else {
+                offset + UPLOAD_PART_SIZE
+            };
+            self.upload_part(data.slice(offset..end));
+            offset = end;
+        }
+        self.upload_part(data);
+    }
+
+    async fn finish(&mut self) -> StorageResult<()> {
+        let parts = self.collect_parts().await?;
+        let upload = CompletedMultipartUpload::builder()
+            .set_parts(Some(parts))
+            .build();
+        self.client
+            .complete_multipart_upload()
+            .bucket(self.bucket_name.clone())
+            .key(self.key.clone())
+            .upload_id(self.upload_id.clone())
+            .multipart_upload(upload)
+            .send()
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                let msg = e.to_string();
+                StorageError { msg }
+            })
+    }
+}

--- a/src/storage/src/aws_s3/storage.rs
+++ b/src/storage/src/aws_s3/storage.rs
@@ -1,0 +1,121 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+use aws_sdk_s3::{
+    model::{BucketLocationConstraint, CreateBucketConfiguration, PublicAccessBlockConfiguration},
+    Client, Config, Credentials, Region,
+};
+
+use crate::{
+    aws_s3::bucket_handle::S3BucketHandle, bucket_handle::BucketHandle, error::StorageResult,
+    ObjectStorage, StorageError,
+};
+
+pub struct RemoteS3Storage {
+    client: Client,
+}
+
+impl RemoteS3Storage {
+    pub fn new(
+        region: impl Into<String>,
+        access_key: impl Into<String>,
+        secret_key: impl Into<String>,
+    ) -> Self {
+        let credentials = Credentials::from_keys(access_key, secret_key, None);
+        let client = Client::from_conf(
+            Config::builder()
+                .region(Some(Region::new(region.into())))
+                .credentials_provider(credentials)
+                .build(),
+        );
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl ObjectStorage for RemoteS3Storage {
+    fn bucket(&self, name: impl Into<String>) -> Box<dyn BucketHandle> {
+        let handle = S3BucketHandle::new(self.client.clone(), name.into());
+        Box::new(handle)
+    }
+
+    async fn create_bucket(&self, name: &str, location: &str) -> StorageResult<()> {
+        self.client
+            .create_bucket()
+            .bucket(name)
+            .create_bucket_configuration(
+                CreateBucketConfiguration::builder()
+                    .location_constraint(BucketLocationConstraint::from(location))
+                    .build(),
+            )
+            .send()
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                let msg = e.to_string();
+                StorageError { msg }
+            })?;
+
+        self.client
+            .put_public_access_block()
+            .bucket(name)
+            .public_access_block_configuration(
+                PublicAccessBlockConfiguration::builder()
+                    .restrict_public_buckets(true)
+                    .block_public_policy(true)
+                    .ignore_public_acls(true)
+                    .block_public_acls(true)
+                    .build(),
+            )
+            .send()
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                let msg = e.to_string();
+                StorageError { msg }
+            })
+    }
+
+    async fn list_buckets(&self) -> StorageResult<Vec<String>> {
+        self.client
+            .list_buckets()
+            .send()
+            .await
+            .map(|bs| {
+                bs.buckets
+                    .unwrap_or(vec![])
+                    .iter()
+                    .map(|b| b.name.clone().unwrap_or_default())
+                    .collect()
+            })
+            .map_err(|e| {
+                let msg = e.to_string();
+                StorageError { msg }
+            })
+    }
+
+    async fn delete_bucket(&self, name: &str) -> StorageResult<()> {
+        self.client
+            .delete_bucket()
+            .bucket(name)
+            .send()
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                let msg = e.to_string();
+                StorageError { msg }
+            })
+    }
+}

--- a/src/storage/src/bucket_handle.rs
+++ b/src/storage/src/bucket_handle.rs
@@ -13,12 +13,22 @@
 // limitations under the License.
 
 use async_trait::async_trait;
+use bytes::Bytes;
 
-use crate::{error::StorageResult, object_handle::ObjectHandle};
+use crate::{
+    error::StorageResult,
+    object_handle::{ObjectReader, ObjectWriter},
+};
 
 #[async_trait]
 pub trait BucketHandle {
-    fn object(&self, name: &str) -> Box<dyn ObjectHandle>;
+    async fn new_writer(&self, name: &str) -> StorageResult<Box<dyn ObjectWriter>>;
+
+    async fn new_reader(&self, name: &str) -> Box<dyn ObjectReader>;
+
+    async fn put_object(&self, name: &str, body: Bytes) -> StorageResult<()>;
 
     async fn delete_object(&self, name: &str) -> StorageResult<()>;
+
+    async fn delete_objects(&self, key: Vec<String>) -> StorageResult<()>;
 }

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub struct StorageError {}
+#[derive(Debug)]
+pub struct StorageError {
+    pub msg: String,
+}
 
 pub type StorageResult<T> = Result<T, StorageError>;

--- a/src/storage/src/object_storage.rs
+++ b/src/storage/src/object_storage.rs
@@ -18,9 +18,11 @@ use crate::{bucket_handle::BucketHandle, error::StorageResult};
 
 #[async_trait]
 pub trait ObjectStorage {
-    fn bucket(&self, name: &str) -> Box<dyn BucketHandle>;
+    fn bucket(&self, name: impl Into<String>) -> Box<dyn BucketHandle>;
 
-    async fn create_bucket(&self, name: &str) -> StorageResult<()>;
+    async fn create_bucket(&self, name: &str, location: &str) -> StorageResult<()>;
 
     async fn delete_bucket(&self, name: &str) -> StorageResult<()>;
+
+    async fn list_buckets(&self) -> StorageResult<Vec<String>>;
 }


### PR DESCRIPTION
ref #68 and move almost code in demo-1 to here

it also has some changes for demo-1

- support create/list/delete buckets
- support delete more than one object at the same time
- support simple one part put object

it also proposes to change some trait definitions in #68 

-  maybe separate "object handler" into  "reader" and "write"
   - reader: to handle read logic
   - writer: to handle multipart write logic(write multiple times and finish once)

still, need handle tasks:

- Storage error
- Retry logic
- Select API
- Write two small multi parts report error.
