### PR TITLE
storage: add a grpc remote storage

### DIFF
--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -44,6 +44,7 @@ jobs:
       with:
         profile: minimal
         toolchain: ${{ matrix.rust }}
+        components: rustfmt
         override: true
 
     - name: Cargo build
@@ -97,6 +98,7 @@ jobs:
       with:
           profile: minimal
           toolchain: nightly
+          components: rustfmt
           override: true
 
     - name: Cargo build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,46 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
+
+[[package]]
 name = "api"
 version = "0.1.0"
 dependencies = [
  "datatypes",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -74,6 +110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,6 +169,12 @@ name = "datatypes"
 version = "0.1.0"
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "engula"
 version = "0.1.0"
 dependencies = [
@@ -136,6 +184,12 @@ dependencies = [
  "storage",
  "tokio",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398ea4fabe40b9b0d885340a2a991a44c8a645624075ad966d21f88688e2b69e"
 
 [[package]]
 name = "fnv"
@@ -259,6 +313,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +399,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -337,6 +411,18 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -356,6 +442,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -470,6 +565,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +636,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +676,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "proc-macro-error"
@@ -612,6 +729,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,12 +791,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -721,8 +957,11 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures",
+ "prost",
  "thiserror",
  "tokio",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -747,6 +986,20 @@ name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
 
 [[package]]
 name = "termcolor"
@@ -807,6 +1060,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +1078,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -832,6 +1106,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24203b79cf2d68909da91178db3026e77054effba0c5d93deb870d3ca7b35afa"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88358bb1dcfeb62dcce85c63006cafb964b7be481d522b7e09589d4d1e718d2a"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,9 +1156,13 @@ checksum = "c00e500fff5fa1131c866b246041a6bf96da9c965f8fe4128cb1421f23e93c00"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tower-layer",
  "tower-service",
@@ -910,6 +1231,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +1304,17 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "which"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -9,3 +9,8 @@ thiserror = "1.0"
 async-trait = "0.1"
 futures = "0.3"
 tokio = { version = "1.13", features = ["full"] }
+tonic = "0.6"
+prost = "0.9"
+
+[build-dependencies]
+tonic-build = "0.6"

--- a/src/storage/build.rs
+++ b/src/storage/build.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::compile_protos("src/grpc/storage.proto")?;
+    Ok(())
+}

--- a/src/storage/build.rs
+++ b/src/storage/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("src/grpc/storage.proto")?;
     Ok(())

--- a/src/storage/src/grpc/bucket.rs
+++ b/src/storage/src/grpc/bucket.rs
@@ -1,0 +1,109 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use futures::{future, stream};
+
+use super::{
+    client::Client,
+    object::RemoteObject,
+    proto::{DeleteObjectRequest, ListObjectsRequest, UploadObjectRequest},
+};
+use crate::{async_trait, Bucket, Object, ObjectUploader, Result, ResultStream};
+
+pub struct RemoteBucket {
+    client: Client,
+    bucket: String,
+}
+
+impl RemoteBucket {
+    pub fn new(client: Client, bucket: String) -> RemoteBucket {
+        RemoteBucket { client, bucket }
+    }
+}
+
+#[async_trait]
+impl Bucket for RemoteBucket {
+    async fn object(&self, name: &str) -> Result<Box<dyn Object>> {
+        let object = RemoteObject::new(self.client.clone(), self.bucket.clone(), name.to_owned());
+        Ok(Box::new(object))
+    }
+
+    async fn list_objects(&self) -> ResultStream<String> {
+        let input = ListObjectsRequest {
+            bucket: self.bucket.clone(),
+        };
+        match self.client.list_objects(input).await {
+            Ok(output) => {
+                let object_names = output
+                    .objects
+                    .into_iter()
+                    .map(Ok)
+                    .collect::<Vec<Result<String>>>();
+                Box::new(stream::iter(object_names))
+            }
+            Err(err) => Box::new(stream::once(future::err(err.into()))),
+        }
+    }
+
+    async fn upload_object(&self, name: &str) -> Box<dyn ObjectUploader> {
+        let uploader =
+            RemoteObjectUploader::new(self.client.clone(), self.bucket.clone(), name.to_owned());
+        Box::new(uploader)
+    }
+
+    async fn delete_object(&self, name: &str) -> Result<()> {
+        let input = DeleteObjectRequest {
+            bucket: self.bucket.clone(),
+            object: name.to_owned(),
+        };
+        let _ = self.client.delete_object(input).await?;
+        Ok(())
+    }
+}
+
+struct RemoteObjectUploader {
+    client: Client,
+    bucket: String,
+    object: String,
+    content: Vec<u8>,
+}
+
+impl RemoteObjectUploader {
+    fn new(client: Client, bucket: String, object: String) -> RemoteObjectUploader {
+        RemoteObjectUploader {
+            client,
+            bucket,
+            object,
+            content: Vec::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectUploader for RemoteObjectUploader {
+    async fn write(&mut self, buf: &[u8]) {
+        self.content.extend_from_slice(buf);
+    }
+
+    async fn finish(self) -> Result<usize> {
+        let len = self.content.len();
+        let input = UploadObjectRequest {
+            bucket: self.bucket,
+            object: self.object,
+            content: self.content,
+        };
+        let _ = self.client.upload_object(input).await?;
+        Ok(len)
+    }
+}

--- a/src/storage/src/grpc/bucket.rs
+++ b/src/storage/src/grpc/bucket.rs
@@ -45,11 +45,7 @@ impl Bucket for RemoteBucket {
         };
         match self.client.list_objects(input).await {
             Ok(output) => {
-                let object_names = output
-                    .objects
-                    .into_iter()
-                    .map(Ok)
-                    .collect::<Vec<Result<String>>>();
+                let object_names = output.objects.into_iter().map(Ok);
                 Box::new(stream::iter(object_names))
             }
             Err(err) => Box::new(stream::once(future::err(err.into()))),

--- a/src/storage/src/grpc/client.rs
+++ b/src/storage/src/grpc/client.rs
@@ -1,0 +1,58 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use tonic::{transport::Channel, Request};
+
+use super::{error::Result, proto::*};
+
+type StorageClient = storage_client::StorageClient<Channel>;
+
+#[derive(Clone)]
+pub struct Client {
+    client: StorageClient,
+}
+
+macro_rules! method {
+    ($name:ident, $input:ty, $output:ty) => {
+        pub async fn $name(&self, input: $input) -> Result<$output> {
+            let mut client = self.client.clone();
+            let request = Request::new(input);
+            let response = client.$name(request).await?;
+            Ok(response.into_inner())
+        }
+    };
+}
+
+impl Client {
+    method!(list_buckets, ListBucketsRequest, ListBucketsResponse);
+
+    method!(create_bucket, CreateBucketRequest, CreateBucketResponse);
+
+    method!(delete_bucket, DeleteBucketRequest, DeleteBucketResponse);
+
+    method!(list_objects, ListObjectsRequest, ListObjectsResponse);
+
+    method!(upload_object, UploadObjectRequest, UploadObjectResponse);
+
+    method!(delete_object, DeleteObjectRequest, DeleteObjectResponse);
+
+    method!(show_object, ShowObjectRequest, ShowObjectResponse);
+
+    method!(read_object, ReadObjectRequest, ReadObjectResponse);
+
+    pub async fn connect(addr: &str) -> Result<Client> {
+        let client = StorageClient::connect(addr.to_owned()).await?;
+        Ok(Client { client })
+    }
+}

--- a/src/storage/src/grpc/mod.rs
+++ b/src/storage/src/grpc/mod.rs
@@ -12,24 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(map_try_insert)]
-
 mod bucket;
+mod client;
 mod error;
 mod object;
+mod proto;
 mod storage;
 
-pub mod grpc;
-pub mod mem;
-
-pub use async_trait::async_trait;
-
-// TODO: use std::stream::Stream instead
-pub type ResultStream<T> = Box<dyn futures::stream::Stream<Item = Result<T>> + Unpin>;
-
-pub use self::{
-    bucket::{Bucket, ObjectUploader},
-    error::{Error, Result},
-    object::Object,
-    storage::Storage,
-};
+pub use self::storage::RemoteStorage;

--- a/src/storage/src/grpc/object.rs
+++ b/src/storage/src/grpc/object.rs
@@ -1,0 +1,62 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::{
+    client::Client,
+    proto::{ReadObjectRequest, ShowObjectRequest},
+};
+use crate::{async_trait, Object, Result};
+
+pub struct RemoteObject {
+    client: Client,
+    bucket: String,
+    object: String,
+}
+
+impl RemoteObject {
+    pub fn new(client: Client, bucket: String, object: String) -> RemoteObject {
+        RemoteObject {
+            client,
+            bucket,
+            object,
+        }
+    }
+}
+
+#[async_trait]
+impl Object for RemoteObject {
+    async fn size(&self) -> Result<usize> {
+        let input = ShowObjectRequest {
+            bucket: self.bucket.clone(),
+            object: self.object.clone(),
+        };
+        let output = self.client.show_object(input).await?;
+        Ok(output.size as usize)
+    }
+
+    async fn read_at(&self, buf: &mut [u8], offset: usize) -> Result<usize> {
+        let input = ReadObjectRequest {
+            bucket: self.bucket.clone(),
+            object: self.object.clone(),
+            offset: offset as i64,
+            length: buf.len() as i64,
+        };
+        let output = self.client.read_object(input).await?;
+        let content = output.content;
+        // TODO: refine the interface to avoid copy here.
+        assert!(content.len() <= buf.len());
+        buf[..content.len()].copy_from_slice(&content);
+        Ok(content.len())
+    }
+}

--- a/src/storage/src/grpc/proto.rs
+++ b/src/storage/src/grpc/proto.rs
@@ -12,24 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(map_try_insert)]
-
-mod bucket;
-mod error;
-mod object;
-mod storage;
-
-pub mod grpc;
-pub mod mem;
-
-pub use async_trait::async_trait;
-
-// TODO: use std::stream::Stream instead
-pub type ResultStream<T> = Box<dyn futures::stream::Stream<Item = Result<T>> + Unpin>;
-
-pub use self::{
-    bucket::{Bucket, ObjectUploader},
-    error::{Error, Result},
-    object::Object,
-    storage::Storage,
-};
+tonic::include_proto!("engula.storage.grpc.v1");

--- a/src/storage/src/grpc/storage.proto
+++ b/src/storage/src/grpc/storage.proto
@@ -1,3 +1,17 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 syntax = "proto3";
 
 package engula.storage.grpc.v1;

--- a/src/storage/src/grpc/storage.proto
+++ b/src/storage/src/grpc/storage.proto
@@ -1,0 +1,88 @@
+syntax = "proto3";
+
+package engula.storage.grpc.v1;
+
+service Storage {
+    // APIs to manipulate buckets.
+
+    rpc ListBuckets(ListBucketsRequest) returns (ListBucketsResponse) {}
+
+    rpc CreateBucket(CreateBucketRequest) returns (CreateBucketResponse) {}
+
+    rpc DeleteBucket(DeleteBucketRequest) returns (DeleteBucketResponse) {}
+
+    // APIs to manipulate a bucket.
+
+    rpc ListObjects(ListObjectsRequest) returns (ListObjectsResponse) {}
+
+    rpc UploadObject(UploadObjectRequest) returns (UploadObjectResponse) {}
+
+    rpc DeleteObject(DeleteObjectRequest) returns (DeleteObjectResponse) {}
+
+    // APIs to manipulate an object.
+
+    rpc ShowObject(ShowObjectRequest) returns (ShowObjectResponse) {}
+
+    rpc ReadObject(ReadObjectRequest) returns (ReadObjectResponse) {}
+}
+
+message ListBucketsRequest {}
+
+message ListBucketsResponse {
+    repeated string buckets = 1;
+}
+
+message CreateBucketRequest {
+    string bucket = 1;
+}
+
+message CreateBucketResponse {}
+
+message DeleteBucketRequest {
+    string bucket = 1;
+}
+
+message DeleteBucketResponse {}
+
+message ListObjectsRequest {
+    string bucket = 1;
+}
+
+message ListObjectsResponse {
+    repeated string objects = 1;
+}
+
+message UploadObjectRequest {
+    string bucket = 1;
+    string object = 2;
+    bytes content = 3;
+}
+
+message UploadObjectResponse {}
+
+message DeleteObjectRequest {
+    string bucket = 1;
+    string object = 2;
+}
+
+message DeleteObjectResponse {}
+
+message ShowObjectRequest {
+    string bucket = 1;
+    string object = 2;
+}
+
+message ShowObjectResponse {
+    int64 size = 1;
+}
+
+message ReadObjectRequest {
+    string bucket = 1;
+    string object = 2;
+    int64 offset = 3;
+    int64 length = 4;
+}
+
+message ReadObjectResponse {
+    bytes content = 1;
+}

--- a/src/storage/src/grpc/storage.rs
+++ b/src/storage/src/grpc/storage.rs
@@ -1,0 +1,72 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use futures::{future, stream};
+
+use super::{
+    bucket::RemoteBucket,
+    client::Client,
+    proto::{CreateBucketRequest, DeleteBucketRequest, ListBucketsRequest},
+};
+use crate::{async_trait, Bucket, Result, ResultStream, Storage};
+
+pub struct RemoteStorage {
+    client: Client,
+}
+
+impl RemoteStorage {
+    pub async fn connect(addr: &str) -> Result<RemoteStorage> {
+        let client = Client::connect(addr).await?;
+        Ok(RemoteStorage { client })
+    }
+}
+
+#[async_trait]
+impl Storage for RemoteStorage {
+    async fn bucket(&self, name: &str) -> Result<Box<dyn Bucket>> {
+        let bucket = RemoteBucket::new(self.client.clone(), name.to_owned());
+        Ok(Box::new(bucket))
+    }
+
+    async fn list_buckets(&self) -> ResultStream<String> {
+        let input = ListBucketsRequest {};
+        match self.client.list_buckets(input).await {
+            Ok(output) => {
+                let bucket_names = output
+                    .buckets
+                    .into_iter()
+                    .map(Ok)
+                    .collect::<Vec<Result<String>>>();
+                Box::new(stream::iter(bucket_names))
+            }
+            Err(err) => Box::new(stream::once(future::err(err.into()))),
+        }
+    }
+
+    async fn create_bucket(&self, name: &str) -> Result<Box<dyn Bucket>> {
+        let input = CreateBucketRequest {
+            bucket: name.to_owned(),
+        };
+        let _ = self.client.create_bucket(input).await?;
+        self.bucket(name).await
+    }
+
+    async fn delete_bucket(&self, name: &str) -> Result<()> {
+        let input = DeleteBucketRequest {
+            bucket: name.to_owned(),
+        };
+        let _ = self.client.delete_bucket(input).await?;
+        Ok(())
+    }
+}

--- a/src/storage/src/grpc/storage.rs
+++ b/src/storage/src/grpc/storage.rs
@@ -43,11 +43,7 @@ impl Storage for RemoteStorage {
         let input = ListBucketsRequest {};
         match self.client.list_buckets(input).await {
             Ok(output) => {
-                let bucket_names = output
-                    .buckets
-                    .into_iter()
-                    .map(Ok)
-                    .collect::<Vec<Result<String>>>();
+                let bucket_names = output.buckets.into_iter().map(Ok);
                 Box::new(stream::iter(bucket_names))
             }
             Err(err) => Box::new(stream::once(future::err(err.into()))),
@@ -58,7 +54,7 @@ impl Storage for RemoteStorage {
         let input = CreateBucketRequest {
             bucket: name.to_owned(),
         };
-        let _ = self.client.create_bucket(input).await?;
+        self.client.create_bucket(input).await?;
         self.bucket(name).await
     }
 
@@ -66,7 +62,7 @@ impl Storage for RemoteStorage {
         let input = DeleteBucketRequest {
             bucket: name.to_owned(),
         };
-        let _ = self.client.delete_bucket(input).await?;
+        self.client.delete_bucket(input).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR only implements the client part of the storage and leaves the server part to future PRs.

This storage uses gRPC for communications. Since the storage APIs are very simple, maybe we can find a more efficient way for RPC in the future. As long as the user interface remains the same, we will be fine.

The API design mostly follows the [Google API design guide](https://cloud.google.com/apis/design) and the [googleapis](https://github.com/googleapis/googleapis/blob/master/google/storage/v2/storage.proto), which is very nice and worth reading. However, most part of the current implementation is suboptimal in order to keep things simple for now.