### PR TITLE
fix aduit vulnerability and warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "datatypes",
 ]
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "background"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
 ]
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "datatypes"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "either"
@@ -176,7 +176,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "engula"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "journal",
@@ -461,7 +461,7 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "journal"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "manifest"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
 ]
@@ -526,7 +526,7 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "microunit"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "storage"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "axum"
-version = "0.3.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c3f630b925c7a85089ff794fdce495c88c80d38710f31eb9817c8399fd77ce"
+checksum = "ebef2d70f09908abd9bedd61f62db165e051eb7643c48ab1642b568b685752a0"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -391,9 +391,9 @@ checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.14"
+version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b91bb1f221b6ea1f1e4371216b70f40748774c2fb5971b450c07773fb92d26b"
+checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -477,9 +477,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.106"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "lock_api"
@@ -899,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e277c495ac6cd1a01a58d0a0c574568b4d1ddf14f59965c6a58b8d96400b54f3"
 dependencies = [
  "itoa",
  "ryu",
@@ -1041,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1171,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b56efe69aa0ad2b5da6b942e57ea9f6fe683b7a314d4ff48662e2c8838de1"
+checksum = "6f70061b0592867f0a60e67a6e699da5fe000c88a360a5b92ebdba9d73b2238c"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "engula"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [workspace]

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "api"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/src/api/datatypes/Cargo.toml
+++ b/src/api/datatypes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datatypes"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/src/background/Cargo.toml
+++ b/src/background/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "background"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/src/journal/Cargo.toml
+++ b/src/journal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "journal"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/src/manifest/Cargo.toml
+++ b/src/manifest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manifest"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/src/microunit/Cargo.toml
+++ b/src/microunit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microunit"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
* fix: the next release version is 0.2.0 (this fixes the warning reported by cargo audit)
* dep: update tokio to fix aduit vulnerability (this fixes the vulnerability reported newly by cargo audit)

@huachaohuang @zojw you can review this PR. It has an overlap with #99 but focuses on fixing all audit reports. It should be OK to rebase one after the other merged first. Or @zojw merge the change on "version = 0.1.0" to "version = 0.2.0" and I can close this PR as integrated in #99 .

This closes #111 .