### PR TITLE
microunit: add a node client and status API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,11 +382,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "engula"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "clap",
  "microunit",
+ "serde_json",
  "tokio",
 ]
 
@@ -410,6 +421,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -663,6 +689,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +730,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -788,8 +844,11 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "axum",
+ "hyper",
+ "reqwest",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "uuid",
 ]
@@ -827,6 +886,24 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "native-tls"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "ntapi"
@@ -873,10 +950,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
+name = "openssl"
+version = "0.10.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -959,6 +1063,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "ppv-lite86"
@@ -1146,6 +1256,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
 ]
 
 [[package]]
@@ -1521,6 +1666,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "tokio"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,6 +1719,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -1748,6 +1918,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1772,6 +1957,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1780,6 +1977,12 @@ dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1826,6 +2029,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1918,6 +2133,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,5 @@ microunit = { path = "src/microunit" }
 
 clap = "3.0.0-beta.5"
 tokio = { version = "1", features = ["full"] }
+anyhow = "1.0"
+serde_json = "1.0"

--- a/src/hello_unit.rs
+++ b/src/hello_unit.rs
@@ -20,7 +20,7 @@ pub struct HelloUnit {
 
 #[async_trait]
 impl Unit for HelloUnit {
-    async fn desc(&self) -> UnitDesc {
+    async fn status(&self) -> UnitDesc {
         UnitDesc {
             id: self.id.clone(),
         }

--- a/src/microunit/Cargo.toml
+++ b/src/microunit/Cargo.toml
@@ -7,7 +7,10 @@ publish = false
 [dependencies]
 async-trait = "0.1"
 axum = "0.3"
+hyper = "0.14"
 tokio = "1.13"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+reqwest = { version = "0.11", features = ["json"] }
+thiserror = "1.0"

--- a/src/microunit/src/error.rs
+++ b/src/microunit/src/error.rs
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[derive(Debug)]
-pub enum Error {
-    InvalidArgument,
-}
+use thiserror::Error;
 
-impl ToString for Error {
-    fn to_string(&self) -> String {
-        format!("{:?}", self)
-    }
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Hyper(#[from] hyper::Error),
+    #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+    #[error("invalid argument")]
+    InvalidArgument,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/microunit/src/lib.rs
+++ b/src/microunit/src/lib.rs
@@ -14,6 +14,7 @@
 
 mod error;
 mod node;
+mod node_client;
 mod node_server;
 mod unit;
 
@@ -22,6 +23,7 @@ pub use async_trait::async_trait;
 pub use self::{
     error::{Error, Result},
     node::{Node, NodeBuilder},
+    node_client::NodeClient,
     node_server::NodeServer,
     unit::{Unit, UnitBuilder, UnitDesc, UnitSpec},
 };

--- a/src/microunit/src/lib.rs
+++ b/src/microunit/src/lib.rs
@@ -15,6 +15,7 @@
 mod error;
 mod node;
 mod node_client;
+mod node_router;
 mod node_server;
 mod unit;
 

--- a/src/microunit/src/node.rs
+++ b/src/microunit/src/node.rs
@@ -45,7 +45,7 @@ impl Node {
         let inner = self.inner.lock().await;
         let mut descs = Vec::new();
         for unit in inner.units.values() {
-            descs.push(unit.desc().await);
+            descs.push(unit.status().await);
         }
         descs
     }
@@ -55,7 +55,7 @@ impl Node {
         if let Some(builder) = inner.unit_builders.get(&spec.kind) {
             let id = Uuid::new_v4().to_string();
             let unit = builder.spawn(id.clone(), spec).await?;
-            let desc = unit.desc().await;
+            let desc = unit.status().await;
             assert!(inner.units.insert(id, unit).is_none());
             Ok(desc)
         } else {

--- a/src/microunit/src/node.rs
+++ b/src/microunit/src/node.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
@@ -21,6 +22,56 @@ use crate::{
     error::{Error, Result},
     unit::{Unit, UnitBuilder, UnitDesc, UnitSpec},
 };
+
+/// A node manages a set of units.
+pub struct Node {
+    id: String,
+    inner: Mutex<Inner>,
+}
+
+struct Inner {
+    units: HashMap<String, Box<dyn Unit>>,
+    unit_builders: HashMap<String, Box<dyn UnitBuilder>>,
+}
+
+impl Node {
+    pub fn status(&self) -> NodeDesc {
+        NodeDesc {
+            id: self.id.clone(),
+        }
+    }
+
+    pub async fn list_units(&self) -> Vec<UnitDesc> {
+        let inner = self.inner.lock().await;
+        let mut descs = Vec::new();
+        for unit in inner.units.values() {
+            descs.push(unit.desc().await);
+        }
+        descs
+    }
+
+    pub async fn create_unit(&self, spec: UnitSpec) -> Result<UnitDesc> {
+        let mut inner = self.inner.lock().await;
+        if let Some(builder) = inner.unit_builders.get(&spec.kind) {
+            let id = Uuid::new_v4().to_string();
+            let unit = builder.spawn(id.clone(), spec).await?;
+            let desc = unit.desc().await;
+            assert!(inner.units.insert(id, unit).is_none());
+            Ok(desc)
+        } else {
+            Err(Error::InvalidArgument)
+        }
+    }
+
+    pub async fn delete_unit(&self, _uid: &str) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct NodeDesc {
+    pub id: String,
+}
 
 #[derive(Default)]
 pub struct NodeBuilder {
@@ -35,50 +86,13 @@ impl NodeBuilder {
     }
 
     pub fn build(self) -> Node {
-        let core = Core {
+        let inner = Inner {
             units: HashMap::new(),
             unit_builders: self.unit_builders,
         };
         Node {
-            core: Mutex::new(core),
+            id: Uuid::new_v4().to_string(),
+            inner: Mutex::new(inner),
         }
     }
-}
-
-/// A node manages a set of units.
-pub struct Node {
-    core: Mutex<Core>,
-}
-
-impl Node {
-    pub async fn list_units(&self) -> Vec<UnitDesc> {
-        let core = self.core.lock().await;
-        let mut descs = Vec::new();
-        for unit in core.units.values() {
-            descs.push(unit.desc().await);
-        }
-        descs
-    }
-
-    pub async fn create_unit(&self, spec: UnitSpec) -> Result<UnitDesc> {
-        let mut core = self.core.lock().await;
-        if let Some(builder) = core.unit_builders.get(&spec.kind) {
-            let id = Uuid::new_v4().to_string();
-            let unit = builder.spawn(id.clone(), spec).await?;
-            let desc = unit.desc().await;
-            assert!(core.units.insert(id, unit).is_none());
-            Ok(desc)
-        } else {
-            Err(Error::InvalidArgument)
-        }
-    }
-
-    pub async fn delete_unit(&self, _uid: &str) -> Result<()> {
-        Ok(())
-    }
-}
-
-struct Core {
-    units: HashMap<String, Box<dyn Unit>>,
-    unit_builders: HashMap<String, Box<dyn UnitBuilder>>,
 }

--- a/src/microunit/src/node_client.rs
+++ b/src/microunit/src/node_client.rs
@@ -14,7 +14,7 @@
 
 use reqwest::Client;
 
-use super::{error::Result, node::NodeDesc};
+use crate::{error::Result, node::NodeDesc};
 
 pub struct NodeClient {
     url: String,

--- a/src/microunit/src/node_router.rs
+++ b/src/microunit/src/node_router.rs
@@ -1,0 +1,61 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::Extension, http::StatusCode, response::IntoResponse, routing::get, AddExtensionLayer,
+    Json, Router,
+};
+use serde_json::json;
+
+use crate::{node::Node, unit::UnitSpec};
+
+pub fn route(node: Arc<Node>) -> Router {
+    let v1 = Router::new()
+        .route("/status", get(status))
+        .route("/units", get(list_units).post(create_unit))
+        .layer(AddExtensionLayer::new(node));
+    Router::new().nest("/v1", v1)
+}
+
+async fn status(Extension(node): Extension<Arc<Node>>) -> impl IntoResponse {
+    let desc = node.status();
+    (StatusCode::OK, Json(desc))
+}
+
+async fn list_units(Extension(node): Extension<Arc<Node>>) -> impl IntoResponse {
+    let descs = node.list_units().await;
+    (StatusCode::OK, Json(descs))
+}
+
+async fn create_unit(
+    Json(spec): Json<UnitSpec>,
+    Extension(node): Extension<Arc<Node>>,
+) -> impl IntoResponse {
+    match node.create_unit(spec).await {
+        Ok(desc) => {
+            let resp = json!({
+                "desc": desc,
+            });
+            (StatusCode::CREATED, Json(resp))
+        }
+        Err(err) => {
+            let resp = json!({
+                "error": err.to_string(),
+            });
+            (StatusCode::INTERNAL_SERVER_ERROR, Json(resp))
+        }
+    }
+}

--- a/src/microunit/src/node_server.rs
+++ b/src/microunit/src/node_server.rs
@@ -14,56 +14,77 @@
 
 use std::{net::SocketAddr, sync::Arc};
 
-use axum::{
-    extract::Extension, http::StatusCode, response::IntoResponse, routing::get, AddExtensionLayer,
-    Json, Router, Server,
-};
-use serde_json::json;
+use axum::{Router, Server};
 
-use crate::{node::Node, unit::UnitSpec};
+use super::{error::Result, node::Node};
 
 /// An HTTP server that serves a node.
 pub struct NodeServer {
-    addr: SocketAddr,
+    node: Arc<Node>,
 }
 
 impl NodeServer {
-    pub fn bind(addr: SocketAddr) -> NodeServer {
-        NodeServer { addr }
-    }
-
-    pub async fn serve(&self, node: Node) {
-        let router = Router::new()
-            .route("/units", get(list_units).post(create_unit))
-            .layer(AddExtensionLayer::new(Arc::new(node)));
-        Server::bind(&self.addr)
-            .serve(router.into_make_service())
-            .await
-            .unwrap();
-    }
-}
-
-async fn list_units(Extension(node): Extension<Arc<Node>>) -> impl IntoResponse {
-    let descs = node.list_units().await;
-    (StatusCode::OK, Json(descs))
-}
-
-async fn create_unit(
-    Json(spec): Json<UnitSpec>,
-    Extension(node): Extension<Arc<Node>>,
-) -> impl IntoResponse {
-    match node.create_unit(spec).await {
-        Ok(desc) => {
-            let resp = json!({
-                "desc": desc,
-            });
-            (StatusCode::CREATED, Json(resp))
+    pub fn new(node: Node) -> NodeServer {
+        NodeServer {
+            node: Arc::new(node),
         }
-        Err(err) => {
-            let resp = json!({
-                "error": err.to_string(),
-            });
-            (StatusCode::INTERNAL_SERVER_ERROR, Json(resp))
+    }
+
+    pub async fn bind(&self, addr: SocketAddr) -> Result<()> {
+        let v1 = v1::route(self.node.clone());
+        let router = Router::new().nest("/v1", v1);
+        Server::bind(&addr)
+            .serve(router.into_make_service())
+            .await?;
+        Ok(())
+    }
+}
+
+mod v1 {
+    use std::sync::Arc;
+
+    use axum::{
+        extract::Extension, http::StatusCode, response::IntoResponse, routing::get,
+        AddExtensionLayer, Json, Router,
+    };
+    use serde_json::json;
+
+    use crate::{node::Node, unit::UnitSpec};
+
+    pub fn route(node: Arc<Node>) -> Router {
+        Router::new()
+            .route("/status", get(status))
+            .route("/units", get(list_units).post(create_unit))
+            .layer(AddExtensionLayer::new(node))
+    }
+
+    async fn status(Extension(node): Extension<Arc<Node>>) -> impl IntoResponse {
+        let desc = node.status();
+        (StatusCode::OK, Json(desc))
+    }
+
+    async fn list_units(Extension(node): Extension<Arc<Node>>) -> impl IntoResponse {
+        let descs = node.list_units().await;
+        (StatusCode::OK, Json(descs))
+    }
+
+    async fn create_unit(
+        Json(spec): Json<UnitSpec>,
+        Extension(node): Extension<Arc<Node>>,
+    ) -> impl IntoResponse {
+        match node.create_unit(spec).await {
+            Ok(desc) => {
+                let resp = json!({
+                    "desc": desc,
+                });
+                (StatusCode::CREATED, Json(resp))
+            }
+            Err(err) => {
+                let resp = json!({
+                    "error": err.to_string(),
+                });
+                (StatusCode::INTERNAL_SERVER_ERROR, Json(resp))
+            }
         }
     }
 }

--- a/src/microunit/src/unit.rs
+++ b/src/microunit/src/unit.rs
@@ -17,22 +17,22 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
 
-/// A unit description that describes the current state of a unit.
-#[derive(Serialize, Deserialize, Default)]
-pub struct UnitDesc {
-    pub id: String,
-}
-
 /// A unit specification that specifies the desired state of a unit.
 #[derive(Serialize, Deserialize, Default)]
 pub struct UnitSpec {
     pub kind: String,
 }
 
+/// A unit description that describes the current state of a unit.
+#[derive(Serialize, Deserialize, Default)]
+pub struct UnitDesc {
+    pub id: String,
+}
+
 /// A unit handle.
 #[async_trait]
 pub trait Unit: Send + Sync {
-    async fn desc(&self) -> UnitDesc;
+    async fn status(&self) -> UnitDesc;
 }
 
 /// A unit builder spawns a specific kind of units.


### PR DESCRIPTION
Refactor the code a little bit. Add a `NodeClient` and an API and command to show a node's status.

Command usage:

```
USAGE:
    engula node status <URL>
```