### PR TITLE
microunit: add control unit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -791,6 +791,7 @@ version = "0.2.0"
 dependencies = [
  "async-trait",
  "axum",
+ "hyper",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "engula"
 version = "0.2.0"
 dependencies = [
@@ -413,6 +422,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -666,6 +690,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,6 +731,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
@@ -792,10 +846,12 @@ dependencies = [
  "async-trait",
  "axum",
  "hyper",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "url",
  "uuid",
 ]
 
@@ -832,6 +888,24 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "native-tls"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "ntapi"
@@ -878,10 +952,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
+name = "openssl"
+version = "0.10.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -964,6 +1065,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
 name = "ppv-lite86"
@@ -1151,6 +1258,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
 ]
 
 [[package]]
@@ -1527,6 +1669,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "tokio"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,6 +1722,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -1754,6 +1921,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,6 +1960,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "url"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,6 +1980,12 @@ dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1832,6 +2032,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1924,6 +2136,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,6 +793,7 @@ dependencies = [
  "axum",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "uuid",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod hello_unit;
-
 pub mod node;

--- a/src/microunit/Cargo.toml
+++ b/src/microunit/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 async-trait = "0.1"
 axum = "0.3"
+hyper = "0.14"
 tokio = "1.13"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/microunit/Cargo.toml
+++ b/src/microunit/Cargo.toml
@@ -13,3 +13,5 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
+reqwest = { version = "0.11", features = ["json"] }
+url = "2.2"

--- a/src/microunit/Cargo.toml
+++ b/src/microunit/Cargo.toml
@@ -11,3 +11,4 @@ tokio = "1.13"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+thiserror = "1.0"

--- a/src/microunit/src/control.rs
+++ b/src/microunit/src/control.rs
@@ -16,10 +16,7 @@ use std::collections::HashMap;
 
 use tokio::sync::Mutex;
 
-use crate::{
-    error::Result,
-    proto::{NodeDesc, NodeDescList},
-};
+use crate::{error::Result, proto::*};
 
 pub struct Control {
     inner: Mutex<Inner>,
@@ -40,6 +37,10 @@ struct Inner {
 }
 
 impl Control {
+    pub async fn desc(&self) -> ControlDesc {
+        ControlDesc::default()
+    }
+
     pub async fn list_nodes(&self) -> Result<NodeDescList> {
         let inner = self.inner.lock().await;
         let descs = inner.nodes.values().cloned().collect();

--- a/src/microunit/src/control_api.rs
+++ b/src/microunit/src/control_api.rs
@@ -34,6 +34,6 @@ async fn desc(Extension(ctrl): Extension<Arc<Control>>) -> Result<Json<ControlDe
 }
 
 async fn list_nodes(Extension(ctrl): Extension<Arc<Control>>) -> Result<Json<NodeDescList>> {
-    let descs = ctrl.list_nodes().await?;
-    Ok(descs.into())
+    let list = ctrl.list_nodes().await?;
+    Ok(list.into())
 }

--- a/src/microunit/src/control_api.rs
+++ b/src/microunit/src/control_api.rs
@@ -16,14 +16,21 @@ use std::sync::Arc;
 
 use axum::{extract::Extension, routing::get, AddExtensionLayer, Json, Router};
 
-use crate::{control::Control, error::Result, proto::NodeDescList};
+use crate::{control::Control, error::Result, proto::*};
 
 pub fn route(ctrl: Arc<Control>) -> Router {
     let universe = Router::new().route("/nodes", get(list_nodes));
-    let v1 = Router::new().nest("/universe", universe);
+    let v1 = Router::new()
+        .route("/", get(desc))
+        .nest("/universe", universe);
     Router::new()
         .nest("/v1", v1)
         .layer(AddExtensionLayer::new(ctrl))
+}
+
+async fn desc(Extension(ctrl): Extension<Arc<Control>>) -> Result<Json<ControlDesc>> {
+    let desc = ctrl.desc().await;
+    Ok(desc.into())
 }
 
 async fn list_nodes(Extension(ctrl): Extension<Arc<Control>>) -> Result<Json<NodeDescList>> {

--- a/src/microunit/src/control_unit.rs
+++ b/src/microunit/src/control_unit.rs
@@ -12,32 +12,49 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use microunit::{async_trait, Result, Unit, UnitBuilder, UnitDesc, UnitSpec};
+use async_trait::async_trait;
 
-pub struct HelloUnit {
-    id: String,
+use crate::{
+    proto::{UnitDesc, UnitSpec},
+    unit::{Unit, UnitBuilder, UnitResult},
+};
+
+pub struct ControlUnit {
+    desc: UnitDesc,
+}
+
+impl ControlUnit {
+    fn new(id: String, spec: UnitSpec) -> Self {
+        let desc = UnitDesc {
+            id,
+            kind: spec.kind,
+        };
+        Self { desc }
+    }
 }
 
 #[async_trait]
-impl Unit for HelloUnit {
+impl Unit for ControlUnit {
     async fn desc(&self) -> UnitDesc {
-        UnitDesc {
-            id: self.id.clone(),
-        }
+        self.desc.clone()
+    }
+
+    async fn start(&self) -> UnitResult<()> {
+        Ok(())
     }
 }
 
 #[derive(Default)]
-pub struct HelloUnitBuilder {}
+pub struct ControlUnitBuilder {}
 
 #[async_trait]
-impl UnitBuilder for HelloUnitBuilder {
+impl UnitBuilder for ControlUnitBuilder {
     fn kind(&self) -> &str {
-        "hello"
+        "ControlUnit"
     }
 
-    async fn spawn(&self, id: String, _spec: UnitSpec) -> Result<Box<dyn Unit>> {
-        let unit = HelloUnit { id };
+    async fn spawn(&self, id: String, spec: UnitSpec) -> UnitResult<Box<dyn Unit>> {
+        let unit = ControlUnit::new(id, spec);
         Ok(Box::new(unit))
     }
 }

--- a/src/microunit/src/error.rs
+++ b/src/microunit/src/error.rs
@@ -28,7 +28,7 @@ pub enum Error {
     #[error("{0}")]
     InvalidArgument(String),
     #[error(transparent)]
-    Unknown(#[from] Box<dyn std::error::Error + Send>),
+    Unknown(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl IntoResponse for Error {

--- a/src/microunit/src/error.rs
+++ b/src/microunit/src/error.rs
@@ -27,6 +27,8 @@ use thiserror::Error;
 pub enum Error {
     #[error("{0}")]
     InvalidArgument(String),
+    #[error(transparent)]
+    Unknown(#[from] Box<dyn std::error::Error + Send>),
 }
 
 impl IntoResponse for Error {
@@ -36,6 +38,7 @@ impl IntoResponse for Error {
     fn into_response(self) -> Response<Self::Body> {
         let (code, message) = match self {
             Error::InvalidArgument(m) => (StatusCode::BAD_REQUEST, m),
+            Error::Unknown(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
         };
         let resp = Json(json!({
             "error": {

--- a/src/microunit/src/lib.rs
+++ b/src/microunit/src/lib.rs
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod control;
+mod control_api;
 mod control_unit;
 mod error;
 mod node;
+mod node_api;
 mod node_server;
 mod proto;
 mod unit;

--- a/src/microunit/src/lib.rs
+++ b/src/microunit/src/lib.rs
@@ -23,5 +23,5 @@ pub use self::{
     error::{Error, Result},
     node::{Node, NodeBuilder},
     node_server::NodeServer,
-    unit::{Unit, UnitBuilder, UnitDesc, UnitSpec},
+    unit::{Unit, UnitBuilder, UnitDesc, UnitDescList, UnitSpec},
 };

--- a/src/microunit/src/lib.rs
+++ b/src/microunit/src/lib.rs
@@ -18,8 +18,9 @@ mod control_unit;
 mod error;
 mod node;
 mod node_api;
+mod node_client;
 mod node_server;
 mod proto;
 mod unit;
 
-pub use self::node_server::NodeServer;
+pub use self::{node_client::NodeClient, node_server::NodeServer};

--- a/src/microunit/src/node.rs
+++ b/src/microunit/src/node.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 use crate::{
     control_unit::ControlUnitBuilder,
     error::{Error, Result},
-    proto::{UnitDesc, UnitDescList, UnitSpec},
+    proto::*,
     unit::{Unit, UnitBuilder},
 };
 
@@ -49,6 +49,10 @@ struct Inner {
 }
 
 impl Node {
+    pub async fn desc(&self) -> NodeDesc {
+        NodeDesc::default()
+    }
+
     pub async fn list_units(&self) -> Result<UnitDescList> {
         let inner = self.inner.lock().await;
         let mut descs = Vec::new();

--- a/src/microunit/src/node.rs
+++ b/src/microunit/src/node.rs
@@ -69,7 +69,10 @@ impl Node {
             assert!(core.units.insert(id, unit).is_none());
             Ok(desc)
         } else {
-            Err(Error::InvalidArgument)
+            Err(Error::InvalidArgument(format!(
+                "invalid unit kind '{}'",
+                spec.kind
+            )))
         }
     }
 

--- a/src/microunit/src/node.rs
+++ b/src/microunit/src/node.rs
@@ -49,13 +49,13 @@ struct Inner {
 }
 
 impl Node {
-    pub async fn list_units(&self) -> UnitDescList {
+    pub async fn list_units(&self) -> Result<UnitDescList> {
         let inner = self.inner.lock().await;
         let mut descs = Vec::new();
         for unit in inner.units.values() {
             descs.push(unit.desc().await);
         }
-        descs
+        Ok(descs)
     }
 
     pub async fn create_unit(&self, spec: UnitSpec) -> Result<UnitDesc> {

--- a/src/microunit/src/node_api.rs
+++ b/src/microunit/src/node_api.rs
@@ -16,17 +16,20 @@ use std::sync::Arc;
 
 use axum::{extract::Extension, routing::get, AddExtensionLayer, Json, Router};
 
-use crate::{
-    error::Result,
-    node::Node,
-    proto::{UnitDesc, UnitDescList, UnitSpec},
-};
+use crate::{error::Result, node::Node, proto::*};
 
 pub fn route(node: Arc<Node>) -> Router {
-    let v1 = Router::new().route("/units", get(list_units).post(create_unit));
+    let v1 = Router::new()
+        .route("/", get(desc))
+        .route("/units", get(list_units).post(create_unit));
     Router::new()
         .nest("/v1", v1)
         .layer(AddExtensionLayer::new(node))
+}
+
+async fn desc(Extension(node): Extension<Arc<Node>>) -> Result<Json<NodeDesc>> {
+    let desc = node.desc().await;
+    Ok(desc.into())
 }
 
 async fn list_units(Extension(node): Extension<Arc<Node>>) -> Result<Json<UnitDescList>> {

--- a/src/microunit/src/node_api.rs
+++ b/src/microunit/src/node_api.rs
@@ -33,8 +33,8 @@ async fn desc(Extension(node): Extension<Arc<Node>>) -> Result<Json<NodeDesc>> {
 }
 
 async fn list_units(Extension(node): Extension<Arc<Node>>) -> Result<Json<UnitDescList>> {
-    let descs = node.list_units().await?;
-    Ok(descs.into())
+    let list = node.list_units().await?;
+    Ok(list.into())
 }
 
 async fn create_unit(

--- a/src/microunit/src/node_api.rs
+++ b/src/microunit/src/node_api.rs
@@ -1,0 +1,43 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use axum::{extract::Extension, routing::get, AddExtensionLayer, Json, Router};
+
+use crate::{
+    error::Result,
+    node::Node,
+    proto::{UnitDesc, UnitDescList, UnitSpec},
+};
+
+pub fn route(node: Arc<Node>) -> Router {
+    let v1 = Router::new().route("/units", get(list_units).post(create_unit));
+    Router::new()
+        .nest("/v1", v1)
+        .layer(AddExtensionLayer::new(node))
+}
+
+async fn list_units(Extension(node): Extension<Arc<Node>>) -> Result<Json<UnitDescList>> {
+    let descs = node.list_units().await?;
+    Ok(descs.into())
+}
+
+async fn create_unit(
+    Extension(node): Extension<Arc<Node>>,
+    Json(spec): Json<UnitSpec>,
+) -> Result<Json<UnitDesc>> {
+    let desc = node.create_unit(spec).await?;
+    Ok(desc.into())
+}

--- a/src/microunit/src/node_client.rs
+++ b/src/microunit/src/node_client.rs
@@ -1,0 +1,51 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::net::SocketAddr;
+
+use reqwest::{Client, Url};
+
+use crate::{error::Result, proto::*};
+
+pub struct NodeClient {
+    url: Url,
+    client: Client,
+}
+
+impl NodeClient {
+    pub fn from_addr(addr: &SocketAddr) -> Result<Self> {
+        let url = Url::parse(&format!("http://{}/v1/", addr))?;
+        let client = Client::new();
+        Ok(Self { url, client })
+    }
+
+    pub async fn list_units(&self) -> Result<UnitDescList> {
+        let url = self.url.join("units")?;
+        let list = self.client.get(url).send().await?.json().await?;
+        Ok(list)
+    }
+
+    pub async fn create_unit(&self, spec: UnitSpec) -> Result<UnitDesc> {
+        let url = self.url.join("units")?;
+        let desc = self
+            .client
+            .post(url)
+            .json(&spec)
+            .send()
+            .await?
+            .json()
+            .await?;
+        Ok(desc)
+    }
+}

--- a/src/microunit/src/proto.rs
+++ b/src/microunit/src/proto.rs
@@ -12,11 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod control_unit;
-mod error;
-mod node;
-mod node_server;
-mod proto;
-mod unit;
+use std::cmp::PartialEq;
 
-pub use self::node_server::NodeServer;
+use serde::{Deserialize, Serialize};
+
+/// Describes the specification of a unit.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+pub struct UnitSpec {
+    pub kind: String,
+}
+
+/// Describes the current state of a unit.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+pub struct UnitDesc {
+    pub id: String,
+    pub kind: String,
+}
+
+pub type UnitDescList = Vec<UnitDesc>;

--- a/src/microunit/src/proto.rs
+++ b/src/microunit/src/proto.rs
@@ -27,6 +27,13 @@ pub struct UnitSpec {
 pub struct UnitDesc {
     pub id: String,
     pub kind: String,
+    pub addr: Option<String>,
 }
 
 pub type UnitDescList = Vec<UnitDesc>;
+
+/// Describes the current state of a node.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+pub struct NodeDesc {}
+
+pub type NodeDescList = Vec<NodeDesc>;

--- a/src/microunit/src/proto.rs
+++ b/src/microunit/src/proto.rs
@@ -16,6 +16,12 @@ use std::cmp::PartialEq;
 
 use serde::{Deserialize, Serialize};
 
+/// Describes the current state of a node.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+pub struct NodeDesc {}
+
+pub type NodeDescList = Vec<NodeDesc>;
+
 /// Describes the specification of a unit.
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 pub struct UnitSpec {
@@ -32,8 +38,6 @@ pub struct UnitDesc {
 
 pub type UnitDescList = Vec<UnitDesc>;
 
-/// Describes the current state of a node.
+/// Describes the current state of a control unit.
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
-pub struct NodeDesc {}
-
-pub type NodeDescList = Vec<NodeDesc>;
+pub struct ControlDesc {}

--- a/src/microunit/src/unit.rs
+++ b/src/microunit/src/unit.rs
@@ -13,34 +13,24 @@
 // limitations under the License.
 
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
 
-use crate::error::Result;
+use crate::proto::{UnitDesc, UnitSpec};
 
-/// A unit description that describes the current state of a unit.
-#[derive(Serialize, Deserialize, Default)]
-pub struct UnitDesc {
-    pub id: String,
-}
-
-pub type UnitDescList = Vec<UnitDesc>;
-
-/// A unit specification that specifies the desired state of a unit.
-#[derive(Serialize, Deserialize, Default)]
-pub struct UnitSpec {
-    pub kind: String,
-}
+pub type UnitError = Box<dyn std::error::Error + Send>;
+pub type UnitResult<T> = Result<T, UnitError>;
 
 /// A unit handle.
 #[async_trait]
 pub trait Unit: Send + Sync {
     async fn desc(&self) -> UnitDesc;
+
+    async fn start(&self) -> UnitResult<()>;
 }
 
-/// A unit builder spawns a specific kind of units.
+/// A unit builder that spawns a specific kind of units.
 #[async_trait]
 pub trait UnitBuilder: Send + Sync {
     fn kind(&self) -> &str;
 
-    async fn spawn(&self, id: String, spec: UnitSpec) -> Result<Box<dyn Unit>>;
+    async fn spawn(&self, id: String, spec: UnitSpec) -> UnitResult<Box<dyn Unit>>;
 }

--- a/src/microunit/src/unit.rs
+++ b/src/microunit/src/unit.rs
@@ -23,6 +23,8 @@ pub struct UnitDesc {
     pub id: String,
 }
 
+pub type UnitDescList = Vec<UnitDesc>;
+
 /// A unit specification that specifies the desired state of a unit.
 #[derive(Serialize, Deserialize, Default)]
 pub struct UnitSpec {

--- a/src/node.rs
+++ b/src/node.rs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 use clap::{crate_version, Parser};
-use microunit::{NodeBuilder, NodeServer};
-
-use crate::hello_unit::HelloUnitBuilder;
+use microunit::NodeServer;
 
 #[derive(Parser)]
 #[clap(version = crate_version!())]
@@ -45,9 +43,6 @@ struct StartCommand {
 impl StartCommand {
     async fn run(&self) {
         let addr = self.addr.parse().unwrap();
-        let node = NodeBuilder::default()
-            .unit(HelloUnitBuilder::default())
-            .build();
-        NodeServer::bind(addr).serve(node).await;
+        NodeServer::bind(addr).serve().await;
     }
 }


### PR DESCRIPTION
This PR implements some ideas from https://github.com/engula/engula/issues/58#issuecomment-974195015 and https://github.com/engula/engula/issues/58#issuecomment-974831557.
It also implements [`IntoResponse`](https://docs.rs/axum/0.3.4/axum/response/trait.IntoResponse.html) for `Error` to convert errors to responses automatically.

We can create a control unit now. First of all, start a node:

```
> cargo run -p engula -- node start 127.0.0.1:1234
```

Then create a control unit:

```
> curl --header "Content-Type: application/json" \
--request POST \
--data '{"kind": "ControlUnit"}' \
http://127.0.0.1:1234/v1/units
```

List all units to get the address of the control unit:

```
> curl http://127.0.0.1:1234/v1/units             
[{"id":"bf099b3f-e6ba-4160-96bf-340dcf7bd048","kind":"ControlUnit","addr":"0.0.0.0:50830"}]
```

Now we can query the control unit:

```
> curl http://127.0.0.1:50830/v1/universe/nodes
[]
```