### PR TITLE
ci: introduce cargo-udeps 

### DIFF
--- a/.github/workflows/audit-license.yml
+++ b/.github/workflows/audit-license.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   audit:
-    name: Audit
+    name: Audit License
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/audit-security.yml
+++ b/.github/workflows/audit-security.yml
@@ -30,6 +30,7 @@ concurrency:
 
 jobs:
   audit-security:
+    name: Audit Security
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'skip audit')"
     steps:

--- a/.github/workflows/check-dependency.yml
+++ b/.github/workflows/check-dependency.yml
@@ -1,0 +1,56 @@
+# Copyright 2021 The Engula Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Check Dependency
+
+on:
+  push:
+    paths:
+      - '**/Cargo.toml'
+  pull_request:
+    paths:
+      - '**/Cargo.toml'
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  udpes:
+    name: Cargo udeps
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: rustfmt
+          override: true
+
+      - name: Install cargo-udeps
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-udeps --locked
+
+      - name: Check udeps
+        uses: actions-rs/cargo@v1
+        with:
+          command: udeps
+          args: --workspace

--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -78,6 +78,12 @@ jobs:
         components: clippy, rustfmt
         override: true
 
+    - name: Install cargo-udeps
+      uses: actions-rs/cargo@v1
+      with:
+        command: install
+        args: cargo-udeps --locked
+
     - name: Check clippy
       uses: actions-rs/cargo@v1
       with:
@@ -89,6 +95,12 @@ jobs:
       with:
         command: fmt
         args: --all -- --check
+
+    - name: Check udeps
+      uses: actions-rs/cargo@v1
+      with:
+          command: udeps
+          args: --workspace
 
   tidy:
     name: Check tidy

--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -78,12 +78,6 @@ jobs:
         components: clippy, rustfmt
         override: true
 
-    - name: Install cargo-udeps
-      uses: actions-rs/cargo@v1
-      with:
-        command: install
-        args: cargo-udeps --locked
-
     - name: Check clippy
       uses: actions-rs/cargo@v1
       with:
@@ -95,12 +89,6 @@ jobs:
       with:
         command: fmt
         args: --all -- --check
-
-    - name: Check udeps
-      uses: actions-rs/cargo@v1
-      with:
-          command: udeps
-          args: --workspace
 
   tidy:
     name: Check tidy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,6 @@ dependencies = [
  "aws-sdk-s3",
  "aws-types",
  "bytes",
- "futures",
  "http",
  "smithy-http",
  "storage",

--- a/src/platform/aws/Cargo.toml
+++ b/src/platform/aws/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 bytes = "1.1"
 thiserror = "1.0"
-futures = "0.3"
 http = "0.2"
 tokio = {version = "1.13", features = ["full"]}
 storage = {path = "../../storage"}


### PR DESCRIPTION
This closes #110.

Although, installing `cargo-udeps` takes about 5 minutes. And it could provide false negative as in [this line](https://github.com/engula/engula/pull/130#discussion_r754994470).