### PR TITLE
storage: refactor with trait objects to allow composition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,147 +74,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "aws"
-version = "0.2.0"
-dependencies = [
- "aws-endpoint",
- "aws-sdk-s3",
- "aws-types",
- "bytes",
- "http",
- "smithy-http",
- "storage",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "aws-auth"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
-dependencies = [
- "aws-types",
- "pin-project",
- "smithy-async",
- "smithy-http",
- "tokio",
- "tracing",
- "zeroize",
-]
-
-[[package]]
-name = "aws-endpoint"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
-dependencies = [
- "aws-types",
- "http",
- "regex",
- "smithy-http",
-]
-
-[[package]]
-name = "aws-http"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
-dependencies = [
- "aws-types",
- "http",
- "lazy_static",
- "smithy-http",
- "smithy-types",
- "thiserror",
-]
-
-[[package]]
-name = "aws-hyper"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
-dependencies = [
- "aws-auth",
- "aws-endpoint",
- "aws-http",
- "aws-sig-auth",
- "bytes",
- "fastrand",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
- "pin-project",
- "smithy-client",
- "smithy-http",
- "smithy-http-tower",
- "smithy-types",
- "tokio",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "aws-sdk-s3"
-version = "0.0.17-alpha"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
-dependencies = [
- "aws-auth",
- "aws-endpoint",
- "aws-http",
- "aws-hyper",
- "aws-sig-auth",
- "aws-types",
- "bytes",
- "http",
- "md5",
- "smithy-client",
- "smithy-eventstream",
- "smithy-http",
- "smithy-types",
- "smithy-xml",
-]
-
-[[package]]
-name = "aws-sig-auth"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
-dependencies = [
- "aws-auth",
- "aws-sigv4",
- "aws-types",
- "http",
- "smithy-eventstream",
- "smithy-http",
- "thiserror",
-]
-
-[[package]]
-name = "aws-sigv4"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
-dependencies = [
- "bytes",
- "chrono",
- "form_urlencoded",
- "hex",
- "http",
- "http-body",
- "percent-encoding",
- "ring",
- "smithy-eventstream",
-]
-
-[[package]]
-name = "aws-types"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
-dependencies = [
- "lazy_static",
- "rustc_version",
- "smithy-async",
- "tracing",
- "zeroize",
-]
-
-[[package]]
 name = "axum"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,16 +134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
-name = "bytes-utils"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e314712951c43123e5920a446464929adc667a5eade7f8fb3997776c9df6e54"
-dependencies = [
- "bytes",
- "either",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,18 +144,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "winapi",
-]
 
 [[package]]
 name = "clap"
@@ -356,24 +193,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
-name = "crc32fast"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "ct-logs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
-dependencies = [
- "sct",
-]
-
-[[package]]
 name = "datatypes"
 version = "0.2.0"
 
@@ -402,12 +221,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
+name = "engula-storage"
+version = "0.2.0"
 dependencies = [
- "instant",
+ "async-trait",
+ "bytes",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -596,12 +420,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "http"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,23 +475,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
-dependencies = [
- "ct-logs",
- "futures-util",
- "hyper",
- "log",
- "rustls",
- "rustls-native-certs",
- "tokio",
- "tokio-rustls",
- "webpki",
 ]
 
 [[package]]
@@ -827,12 +628,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58b6f41fdfbec185dd3dff58b51e323f5bc61692c0de38419a957b0dcfccca3c"
 
 [[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
-
-[[package]]
 name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,25 +708,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1295,55 +1071,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
-dependencies = [
- "openssl-probe",
- "rustls",
- "schannel",
- "security-framework",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,16 +1091,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "security-framework"
@@ -1397,12 +1114,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
@@ -1469,100 +1180,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
-name = "smithy-async"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "smithy-client"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
-dependencies = [
- "bytes",
- "fastrand",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
- "pin-project",
- "smithy-http",
- "smithy-http-tower",
- "smithy-types",
- "tokio",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "smithy-eventstream"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
-dependencies = [
- "bytes",
- "crc32fast",
- "smithy-types",
-]
-
-[[package]]
-name = "smithy-http"
-version = "0.0.1"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
-dependencies = [
- "bytes",
- "bytes-utils",
- "futures-core",
- "http",
- "http-body",
- "hyper",
- "percent-encoding",
- "pin-project",
- "smithy-eventstream",
- "smithy-types",
- "thiserror",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "smithy-http-tower"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
-dependencies = [
- "bytes",
- "http",
- "http-body",
- "pin-project",
- "smithy-http",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "smithy-types"
-version = "0.0.1"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
-dependencies = [
- "chrono",
- "itoa",
- "num-integer",
- "ryu",
-]
-
-[[package]]
-name = "smithy-xml"
-version = "0.1.0"
-source = "git+https://github.com/awslabs/aws-sdk-rust?tag=v0.0.17-alpha#74cd8a14231e1a005a2f554b072fc9782def5519"
-dependencies = [
- "thiserror",
- "xmlparser",
-]
-
-[[package]]
 name = "socket2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,26 +1187,6 @@ checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "storage"
-version = "0.2.0"
-dependencies = [
- "async-trait",
- "bytes",
- "prost",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tonic",
- "tonic-build",
 ]
 
 [[package]]
@@ -1731,17 +1328,6 @@ checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
-dependencies = [
- "rustls",
- "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -1953,12 +1539,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2085,16 +1665,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "which"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,15 +1714,3 @@ checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "xmlparser"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
-
-[[package]]
-name = "zeroize"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ members = [
     "src/manifest",
     "src/background",
     "src/microunit",
-    "src/platform/aws",
 ]
 
 [dependencies]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2021-10-20"
+channel = "nightly-2021-11-16"
 components = ["rustfmt", "clippy"]

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -1,14 +1,13 @@
 [package]
-name = "storage"
+name = "engula-storage"
 version = "0.2.0"
 edition = "2021"
-publish = false
 
 [dependencies]
 thiserror = "1.0"
 async-trait = "0.1"
 bytes = "1.1.0"
-tokio = { version = "1.13", features = ["full"] }
+tokio = { version = "1.14", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.6"
 prost = "0.9"

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -16,23 +16,12 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("`{0}` is not found")]
+    #[error("{0} is not found")]
     NotFound(String),
-    #[error("`{0}` already exists")]
+    #[error("{0} already exists")]
     AlreadyExists(String),
-    #[error("invalid argument: `{0}`")]
+    #[error("{0}")]
     InvalidArgument(String),
-}
-
-impl From<Error> for tonic::Status {
-    fn from(err: Error) -> Self {
-        let (code, message) = match err {
-            Error::NotFound(s) => (tonic::Code::NotFound, s),
-            Error::AlreadyExists(s) => (tonic::Code::AlreadyExists, s),
-            Error::InvalidArgument(s) => (tonic::Code::InvalidArgument, s),
-        };
-        tonic::Status::new(code, message)
-    }
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -12,14 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod error;
 mod object;
 mod storage;
 mod uploader;
 
-pub mod file;
-pub mod grpc;
+// pub mod file;
+// pub mod grpc;
 pub mod mem;
 
 pub use async_trait::async_trait;
 
-pub use self::{object::Object, storage::Storage, uploader::ObjectUploader};
+pub use self::{
+    error::{Error, Result},
+    object::Object,
+    storage::Storage,
+    uploader::ObjectUploader,
+};

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -19,12 +19,13 @@ mod uploader;
 
 // pub mod file;
 // pub mod grpc;
-pub mod mem;
+mod mem;
 
 pub use async_trait::async_trait;
 
 pub use self::{
     error::{Error, Result},
+    mem::MemStorage,
     object::Object,
     storage::Storage,
     uploader::ObjectUploader,

--- a/src/storage/src/mem/mod.rs
+++ b/src/storage/src/mem/mod.rs
@@ -12,16 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod error;
 mod object;
 mod storage;
 mod uploader;
 
-pub use self::{
-    error::{Error, Result},
-    object::MemObject,
-    storage::MemStorage,
-};
+pub use self::storage::MemStorage;
 
 #[cfg(test)]
 mod tests {

--- a/src/storage/src/mem/object.rs
+++ b/src/storage/src/mem/object.rs
@@ -14,8 +14,7 @@
 
 use std::{cmp::min, sync::Arc};
 
-use super::error::{Error, Result};
-use crate::{async_trait, Object};
+use crate::{async_trait, Error, Object, Result};
 
 #[derive(Clone)]
 pub struct MemObject {
@@ -32,8 +31,6 @@ impl MemObject {
 
 #[async_trait]
 impl Object for MemObject {
-    type Error = Error;
-
     async fn read_at(&self, buf: &mut [u8], offset: usize) -> Result<usize> {
         if let Some(length) = self.data.len().checked_sub(offset) {
             let length = min(length, buf.len());

--- a/src/storage/src/object.rs
+++ b/src/storage/src/object.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::async_trait;
+use crate::{async_trait, Result};
 
 /// An interface to manipulate an object.
 #[async_trait]
 pub trait Object {
-    type Error;
-
-    /// Reads a range from the object at a specific offset.
-    async fn read_at(&self, buf: &mut [u8], offset: usize) -> Result<usize, Self::Error>;
+    /// Reads a range from a given offset.
+    async fn read_at(&self, buf: &mut [u8], offset: usize) -> Result<usize>;
 }

--- a/src/storage/src/object.rs
+++ b/src/storage/src/object.rs
@@ -16,7 +16,7 @@ use crate::{async_trait, Result};
 
 /// An interface to manipulate an object.
 #[async_trait]
-pub trait Object {
+pub trait Object: Send + Sync {
     /// Reads a range from a given offset.
     async fn read_at(&self, buf: &mut [u8], offset: usize) -> Result<usize>;
 }

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -16,7 +16,7 @@ use crate::{async_trait, Object, ObjectUploader, Result};
 
 /// An interface to manipulate a storage.
 #[async_trait]
-pub trait Storage {
+pub trait Storage: Send + Sync {
     /// Creates a bucket.
     async fn create_bucket(&self, bucket_name: &str) -> Result<()>;
 

--- a/src/storage/src/storage.rs
+++ b/src/storage/src/storage.rs
@@ -12,28 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{async_trait, object::Object, uploader::ObjectUploader};
+use crate::{async_trait, Object, ObjectUploader, Result};
 
 /// An interface to manipulate a storage.
 #[async_trait]
-pub trait Storage<O: Object> {
-    type ObjectUploader: ObjectUploader<Error = O::Error>;
+pub trait Storage {
     /// Creates a bucket.
-    async fn create_bucket(&self, name: &str) -> Result<(), O::Error>;
+    async fn create_bucket(&self, bucket_name: &str) -> Result<()>;
 
     /// Deletes a bucket.
-    async fn delete_bucket(&self, name: &str) -> Result<(), O::Error>;
+    async fn delete_bucket(&self, bucket_name: &str) -> Result<()>;
 
-    /// Returns an object from a bucket.
-    async fn object(&self, bucket_name: &str, object_name: &str) -> Result<O, O::Error>;
+    /// Returns an object.
+    async fn object(&self, bucket_name: &str, object_name: &str) -> Result<Box<dyn Object>>;
 
-    /// Uploads an object to a bucket.
+    /// Uploads an object.
     async fn upload_object(
         &self,
         bucket_name: &str,
         object_name: &str,
-    ) -> Result<Self::ObjectUploader, O::Error>;
+    ) -> Result<Box<dyn ObjectUploader>>;
 
-    /// Deletes an object from a bucket.
-    async fn delete_object(&self, bucket_name: &str, object_name: &str) -> Result<(), O::Error>;
+    /// Deletes an object.
+    async fn delete_object(&self, bucket_name: &str, object_name: &str) -> Result<()>;
 }

--- a/src/storage/src/uploader.rs
+++ b/src/storage/src/uploader.rs
@@ -16,7 +16,7 @@ use crate::{async_trait, Result};
 
 /// An interface to upload an object.
 #[async_trait]
-pub trait ObjectUploader {
+pub trait ObjectUploader: Send + Sync {
     /// Writes some bytes.
     async fn write(&mut self, buf: &[u8]) -> Result<()>;
 

--- a/src/storage/src/uploader.rs
+++ b/src/storage/src/uploader.rs
@@ -12,16 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::async_trait;
+use crate::{async_trait, Result};
 
 /// An interface to upload an object.
 #[async_trait]
 pub trait ObjectUploader {
-    type Error;
-
     /// Writes some bytes.
-    async fn write(&mut self, buf: &[u8]) -> Result<(), Self::Error>;
+    async fn write(&mut self, buf: &[u8]) -> Result<()>;
 
     /// Finishes this upload.
-    async fn finish(self) -> Result<usize, Self::Error>;
+    async fn finish(self: Box<Self>) -> Result<usize>;
 }


### PR DESCRIPTION
Upper-level modules like Kernel/Engine need to create a storage dynamically without knowing the specific type. Check [this](https://github.com/engula/engula/pull/136) for an example.

Other updates in this PR:

- Update package name to address [this issue](https://github.com/engula/engula/issues/59#issuecomment-980544605)
- Update toolchain to address [this issue](https://github.com/rust-analyzer/rust-analyzer/issues/10772).

I am currently focusing on prototyping the [kernel[(https://github.com/engula/engula/pull/136). So I opt out of some implementations to avoid fixing all of them now.