### PR TITLE
journal: specialize Timestamp

### DIFF
--- a/src/journal/src/grpc/journal.rs
+++ b/src/journal/src/grpc/journal.rs
@@ -12,38 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::marker::PhantomData;
-
 use super::{
     client::Client,
     error::Result,
     proto::{CreateStreamRequest, DeleteStreamRequest},
     stream::RemoteStream,
 };
-use crate::{async_trait, Journal, Timestamp};
+use crate::{async_trait, Journal};
 
-pub struct RemoteJournal<T: Timestamp> {
+pub struct RemoteJournal {
     client: Client,
-    _t: PhantomData<T>,
 }
 
-impl<T: Timestamp> RemoteJournal<T> {
-    pub async fn connect(addr: &str) -> Result<RemoteJournal<T>> {
+impl RemoteJournal {
+    pub async fn connect(addr: &str) -> Result<RemoteJournal> {
         let client = Client::connect(addr).await?;
-        Ok(RemoteJournal {
-            client,
-            _t: PhantomData,
-        })
+        Ok(RemoteJournal { client })
     }
 }
 
 #[async_trait]
-impl<T: Timestamp> Journal<RemoteStream<T>> for RemoteJournal<T> {
-    async fn stream(&self, name: &str) -> Result<RemoteStream<T>> {
+impl Journal<RemoteStream> for RemoteJournal {
+    async fn stream(&self, name: &str) -> Result<RemoteStream> {
         Ok(RemoteStream::new(self.client.clone(), name.to_owned()))
     }
 
-    async fn create_stream(&self, name: &str) -> Result<RemoteStream<T>> {
+    async fn create_stream(&self, name: &str) -> Result<RemoteStream> {
         let input = CreateStreamRequest {
             stream: name.to_owned(),
         };

--- a/src/journal/src/grpc/proto.rs
+++ b/src/journal/src/grpc/proto.rs
@@ -17,10 +17,10 @@ tonic::include_proto!("engula.journal.grpc.v1");
 use super::error::Error;
 use crate::Timestamp;
 
-pub fn serialize_ts<T: Timestamp>(ts: &T) -> Result<Vec<u8>, Error> {
+pub fn serialize_ts(ts: &Timestamp) -> Result<Vec<u8>, Error> {
     serde_json::to_vec(ts).map_err(Error::from)
 }
 
-pub fn deserialize_ts<T: Timestamp>(v: &[u8]) -> Result<T, Error> {
+pub fn deserialize_ts(v: &[u8]) -> Result<Timestamp, Error> {
     serde_json::from_slice(v).map_err(Error::from)
 }

--- a/src/journal/src/grpc/server.rs
+++ b/src/journal/src/grpc/server.rs
@@ -21,23 +21,20 @@ use std::{
 use tonic::{Request, Response, Status};
 
 use super::proto::*;
-use crate::{Event, Journal, Stream, Timestamp};
+use crate::{Event, Journal, Stream};
 
-pub struct Server<S, J, T>
+pub struct Server<S, J>
 where
     S: Stream,
     J: Journal<S>,
-    T: Timestamp,
 {
     journal: J,
     _stream: PhantomData<S>,
-    _t: PhantomData<T>,
 }
 
-impl<S, J, T> Server<S, J, T>
+impl<S, J> Server<S, J>
 where
-    T: Timestamp + 'static,
-    S: Stream<Timestamp = T> + Send + Sync + 'static,
+    S: Stream + Send + Sync + 'static,
     S::Error: Send + Sync + 'static,
     S::EventStream: Send + Sync + 'static,
     J: Journal<S> + Send + Sync + 'static,
@@ -47,20 +44,18 @@ where
         Server {
             journal,
             _stream: PhantomData,
-            _t: PhantomData,
         }
     }
 
-    pub fn into_service(self) -> journal_server::JournalServer<Server<S, J, T>> {
+    pub fn into_service(self) -> journal_server::JournalServer<Server<S, J>> {
         journal_server::JournalServer::new(self)
     }
 }
 
 #[tonic::async_trait]
-impl<S, J, T> journal_server::Journal for Server<S, J, T>
+impl<S, J> journal_server::Journal for Server<S, J>
 where
-    T: Timestamp + 'static,
-    S: Stream<Timestamp = T> + Send + Sync + 'static,
+    S: Stream + Send + Sync + 'static,
     S::Error: Send + Sync + 'static,
     S::EventStream: Send + Sync + 'static,
     J: Journal<S> + Send + Sync + 'static,

--- a/src/journal/src/mem/journal.rs
+++ b/src/journal/src/mem/journal.rs
@@ -20,13 +20,13 @@ use super::{
     error::{Error, Result},
     stream::MemStream,
 };
-use crate::{async_trait, Journal, Timestamp};
+use crate::{async_trait, Journal};
 
-pub struct MemJournal<T: Timestamp> {
-    streams: Mutex<HashMap<String, MemStream<T>>>,
+pub struct MemJournal {
+    streams: Mutex<HashMap<String, MemStream>>,
 }
 
-impl<T: Timestamp> Default for MemJournal<T> {
+impl Default for MemJournal {
     fn default() -> Self {
         MemJournal {
             streams: Mutex::new(HashMap::new()),
@@ -35,8 +35,8 @@ impl<T: Timestamp> Default for MemJournal<T> {
 }
 
 #[async_trait]
-impl<T: Timestamp> Journal<MemStream<T>> for MemJournal<T> {
-    async fn stream(&self, name: &str) -> Result<MemStream<T>> {
+impl Journal<MemStream> for MemJournal {
+    async fn stream(&self, name: &str) -> Result<MemStream> {
         let streams = self.streams.lock().await;
         match streams.get(name) {
             Some(stream) => Ok(stream.clone()),
@@ -44,7 +44,7 @@ impl<T: Timestamp> Journal<MemStream<T>> for MemJournal<T> {
         }
     }
 
-    async fn create_stream(&self, name: &str) -> Result<MemStream<T>> {
+    async fn create_stream(&self, name: &str) -> Result<MemStream> {
         let stream = MemStream::default();
         let mut streams = self.streams.lock().await;
         match streams.entry(name.to_owned()) {

--- a/src/journal/src/mem/mod.rs
+++ b/src/journal/src/mem/mod.rs
@@ -31,14 +31,14 @@ mod tests {
 
     #[tokio::test]
     async fn test() -> Result<()> {
-        let j: MemJournal<u64> = MemJournal::default();
+        let j = MemJournal::default();
         let stream = j.create_stream("a").await?;
         let event = Event {
-            ts: 0,
+            ts: Timestamp::from(0),
             data: vec![1, 2, 3],
         };
         stream.append_event(event.clone()).await?;
-        let mut events = stream.read_events(0).await?;
+        let mut events = stream.read_events(Timestamp::from(0)).await?;
         let got = events.next().await.unwrap()?;
         assert_eq!(got, event);
         Ok(())

--- a/src/journal/src/stream.rs
+++ b/src/journal/src/stream.rs
@@ -14,21 +14,22 @@
 
 use std::fmt::Debug;
 
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Deserialize, Serialize};
 
 use super::async_trait;
 
-/// A generic timestamp to order events.
-pub trait Timestamp:
-    Ord + Send + Sync + Copy + Debug + Unpin + Serialize + DeserializeOwned
-{
+#[derive(PartialEq, PartialOrd, Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct Timestamp(u64);
+
+impl From<u64> for Timestamp {
+    fn from(t: u64) -> Self {
+        Timestamp(t)
+    }
 }
 
-impl<T: Ord + Send + Sync + Copy + Debug + Unpin + Serialize + DeserializeOwned> Timestamp for T {}
-
 #[derive(Clone, Debug, PartialEq)]
-pub struct Event<T: Timestamp> {
-    pub ts: T,
+pub struct Event {
+    pub ts: Timestamp,
     pub data: Vec<u8>,
 }
 
@@ -36,15 +37,14 @@ pub struct Event<T: Timestamp> {
 #[async_trait]
 pub trait Stream {
     type Error;
-    type Timestamp: Timestamp;
-    type EventStream: futures::Stream<Item = Result<Event<Self::Timestamp>, Self::Error>> + Unpin;
+    type EventStream: futures::Stream<Item = Result<Event, Self::Error>> + Unpin;
 
     /// Reads events since a timestamp (inclusive).
-    async fn read_events(&self, ts: Self::Timestamp) -> Result<Self::EventStream, Self::Error>;
+    async fn read_events(&self, ts: Timestamp) -> Result<Self::EventStream, Self::Error>;
 
     /// Appends an event.
-    async fn append_event(&self, event: Event<Self::Timestamp>) -> Result<(), Self::Error>;
+    async fn append_event(&self, event: Event) -> Result<(), Self::Error>;
 
     /// Releases events up to a timestamp (exclusive).
-    async fn release_events(&self, ts: Self::Timestamp) -> Result<(), Self::Error>;
+    async fn release_events(&self, ts: Timestamp) -> Result<(), Self::Error>;
 }


### PR DESCRIPTION
Change Timestamp from trait to a newtype wrapper of u64.

It turns out that a trait-bound marker of Timestamp goes into premature optimization. Even a most complex clock consists of no more than three parts (seconds, nanoseconds, logical clock, all of which are integers).

We can later extend the Timestamp structure to simulate multiple parts, but specialize & simplify it for now.

This is a follow-up to #103.
This refers to #100.

Signed-off-by: tison <wander4096@gmail.com>

cc @huachaohuang @Xuanwo