### PR TITLE
makefile: intro makefile to simplify the local workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+setup:
+	cargo install cargo-audit cargo-udeps
+
+audit:
+	cargo audit
+	cargo udeps --workspace
+
+clean:
+	cargo clean
+
+build:
+	cargo build
+
+clippy:
+	cargo clippy --workspace --tests --all-features -- -D warnings
+
+fmt:
+	cargo fmt
+
+fmt-check:
+	cargo fmt --all -- --check
+
+lint: fmt-check clippy
+
+pre-commit: lint build audit

--- a/tools/ci/licenserc.yml
+++ b/tools/ci/licenserc.yml
@@ -23,6 +23,7 @@ header:
     - 'Cargo.lock'
     - 'Cargo.toml'
     - 'LICENSE'
+    - 'Makefile'
     - 'rust-toolchain.toml'
     - 'rustfmt.toml'
     - '.cargo/audit.toml'


### PR DESCRIPTION

Fixes: #150

add a basic makefile to simplify the local workflow

- make setup: setup all crates
- make lint: fmt check and clippy
- make audit: security audit and find unused deps
- make pre-commit: run all local workflow like ci

Signed-off-by: Chojan Shang <psiace@outlook.com>