### PR TITLE
journal: add a file implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "async-trait",
  "futures",
  "prost",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/src/journal/Cargo.toml
+++ b/src/journal/Cargo.toml
@@ -16,5 +16,8 @@ tokio-stream = { version = "0.1", features = ["net"] }
 tonic = "0.6"
 prost = "0.9"
 
+[dev-dependencies]
+tempfile = "3"
+
 [build-dependencies]
 tonic-build = "0.6"

--- a/src/journal/src/error.rs
+++ b/src/journal/src/error.rs
@@ -23,6 +23,10 @@ pub enum Error {
     AlreadyExists(String),
     #[error("{0}")]
     InvalidArgument(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("corrupted: {0}")]
+    Corrupted(String),
     #[error("unknown: {0}")]
     Unknown(String),
 }

--- a/src/journal/src/file/journal.rs
+++ b/src/journal/src/file/journal.rs
@@ -1,0 +1,70 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{path::PathBuf, sync::Arc};
+
+use tokio::{fs, sync::Mutex};
+
+use super::stream::Stream;
+use crate::{async_trait, Error, Result};
+
+#[derive(Clone)]
+pub struct Journal {
+    root: Arc<Mutex<PathBuf>>,
+    segment_size: u64,
+}
+
+impl Journal {
+    pub async fn open(root: impl Into<PathBuf>, segment_size: u64) -> Result<Self> {
+        let root = root.into();
+        Ok(Self {
+            root: Arc::new(Mutex::new(root)),
+            segment_size,
+        })
+    }
+}
+
+#[async_trait]
+impl crate::Journal for Journal {
+    type Stream = Stream;
+
+    async fn stream(&self, name: &str) -> Result<Stream> {
+        let root = self.root.lock().await;
+        let path = root.join(name);
+        if !path.exists() {
+            return Err(Error::NotFound(format!("stream '{}'", name)));
+        }
+        Stream::open(path, self.segment_size).await
+    }
+
+    async fn create_stream(&self, name: &str) -> Result<Stream> {
+        let root = self.root.lock().await;
+        let path = root.join(name);
+        if path.exists() {
+            return Err(Error::AlreadyExists(format!("stream '{}'", name)));
+        }
+        fs::create_dir_all(&path).await?;
+        Stream::open(path, self.segment_size).await
+    }
+
+    async fn delete_stream(&self, name: &str) -> Result<()> {
+        let root = self.root.lock().await;
+        let path = root.join(name);
+        if !path.exists() {
+            return Err(Error::NotFound(format!("stream '{}'", name)));
+        }
+        fs::remove_dir_all(path).await?;
+        Ok(())
+    }
+}

--- a/src/journal/src/file/mod.rs
+++ b/src/journal/src/file/mod.rs
@@ -1,0 +1,96 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod journal;
+mod segment;
+mod segment_reader;
+mod segment_stream;
+mod stream;
+
+pub use self::{journal::Journal, stream::Stream};
+
+#[cfg(test)]
+mod tests {
+    use futures::TryStreamExt;
+
+    use crate::*;
+
+    #[tokio::test]
+    async fn test() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let root = tmp.path();
+        let stream_name = "stream";
+        let segment_size = 1024;
+
+        // Creates a stream
+        let j = super::Journal::open(root, segment_size).await?;
+        assert!(matches!(
+            j.stream(stream_name).await,
+            Err(Error::NotFound(_))
+        ));
+        let stream = j.create_stream(stream_name).await?;
+        test_stream(&stream, 1, 256).await?;
+
+        // Reopen
+        let j = super::Journal::open(root, segment_size).await?;
+        assert!(matches!(
+            j.create_stream(stream_name).await,
+            Err(Error::AlreadyExists(_))
+        ));
+        let stream = j.stream(stream_name).await?;
+        // This will conflict with the last timestamp.
+        assert!(matches!(
+            test_stream(&stream, 255, 256).await,
+            Err(Error::InvalidArgument(_))
+        ));
+        test_stream(&stream, 256, 512).await?;
+
+        // Deletes a stream
+        j.delete_stream(stream_name).await?;
+        assert!(matches!(
+            j.stream(stream_name).await,
+            Err(Error::NotFound(_))
+        ));
+
+        Ok(())
+    }
+
+    async fn test_stream(stream: &super::Stream, start: u64, limit: u64) -> Result<()> {
+        let mut released_ts = start;
+        for ts in start..limit {
+            let event = Event {
+                ts: ts.into(),
+                data: ts.to_be_bytes().to_vec(),
+            };
+            stream.append_event(event).await?;
+            check_stream(stream, released_ts, ts + 1).await?;
+            if ts % 29 == 0 {
+                released_ts = ts - 17;
+                stream.release_events(released_ts.into()).await?;
+                check_stream(stream, released_ts, ts + 1).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn check_stream(stream: &super::Stream, start: u64, limit: u64) -> Result<()> {
+        let mut events = stream.read_events(start.into()).await;
+        for i in start..limit {
+            for event in events.try_next().await?.unwrap() {
+                assert_eq!(event.ts, i.into());
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/journal/src/file/segment.rs
+++ b/src/journal/src/file/segment.rs
@@ -1,0 +1,97 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::PathBuf;
+
+use futures::TryStreamExt;
+use tokio::{
+    fs::{File, OpenOptions},
+    io::AsyncWriteExt,
+};
+
+use super::segment_stream::SegmentStream;
+use crate::{Error, Event, Result, ResultStream, Timestamp};
+
+pub struct Segment {
+    path: PathBuf,
+    file: File,
+    offset: u64,
+    last_timestamp: Option<Timestamp>,
+}
+
+impl Segment {
+    pub async fn open(
+        path: impl Into<PathBuf>,
+        mut last_timestamp: Option<Timestamp>,
+    ) -> Result<Self> {
+        let path = path.into();
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .await?;
+        let offset = file.metadata().await?.len();
+
+        // Recovers the last timestamp.
+        let mut stream = SegmentStream::open(&path, offset, None).await?;
+        while let Some(events) = stream.try_next().await? {
+            for event in events {
+                last_timestamp = Some(event.ts);
+            }
+        }
+
+        Ok(Self {
+            path,
+            file,
+            offset,
+            last_timestamp,
+        })
+    }
+
+    pub async fn seal(mut self) -> Result<Timestamp> {
+        let ts = self.last_timestamp.ok_or_else(|| {
+            Error::Unknown("should not seal a segment with no timestamp".to_owned())
+        })?;
+        // Records the last timestamp at the file footer.
+        let ts_bytes = ts.serialize();
+        self.file.write_buf(&mut ts_bytes.as_ref()).await?;
+        self.file.write_u32(ts_bytes.len() as u32).await?;
+        self.file.sync_data().await?;
+        Ok(ts)
+    }
+
+    pub async fn read_events(&self, ts: Timestamp) -> Result<ResultStream<Vec<Event>>> {
+        SegmentStream::open(&self.path, self.offset, Some(ts)).await
+    }
+
+    pub async fn append_event(&mut self, event: Event) -> Result<u64> {
+        if let Some(last_ts) = self.last_timestamp {
+            if event.ts <= last_ts {
+                return Err(Error::InvalidArgument(format!(
+                    "event timestamp {:?} <= last event timestamp {:?}",
+                    event.ts, last_ts,
+                )));
+            }
+        }
+        let ts_bytes = event.ts.serialize();
+        self.file.write_u32(ts_bytes.len() as u32).await?;
+        self.file.write_u32(event.data.len() as u32).await?;
+        self.file.write_buf(&mut ts_bytes.as_ref()).await?;
+        self.file.write_buf(&mut event.data.as_ref()).await?;
+        self.file.flush().await?;
+        self.offset += (8 + ts_bytes.len() + event.data.len()) as u64;
+        self.last_timestamp = Some(event.ts);
+        Ok(self.offset)
+    }
+}

--- a/src/journal/src/file/segment_reader.rs
+++ b/src/journal/src/file/segment_reader.rs
@@ -1,0 +1,72 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    io::SeekFrom,
+    path::{Path, PathBuf},
+};
+
+use tokio::{
+    fs::File,
+    io::{AsyncReadExt, AsyncSeekExt},
+};
+
+use super::segment_stream::SegmentStream;
+use crate::{Error, Event, Result, ResultStream, Timestamp};
+
+pub struct SegmentReader {
+    path: PathBuf,
+    max_offset: u64,
+    max_timestamp: Timestamp,
+}
+
+impl SegmentReader {
+    pub async fn open(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        let mut file = File::open(&path).await?;
+        let mut max_offset = file.metadata().await?.len();
+        // Reads the max timestamp from the file footer.
+        if max_offset < 4 {
+            return Err(Error::Corrupted("file size too small".to_owned()));
+        }
+        max_offset -= 4;
+        file.seek(SeekFrom::Start(max_offset)).await?;
+        let ts_len = file.read_u32().await?;
+        if max_offset < ts_len as u64 {
+            return Err(Error::Corrupted("file size too small".to_owned()));
+        }
+        max_offset -= ts_len as u64;
+        file.seek(SeekFrom::Start(max_offset)).await?;
+        let mut ts_buf = vec![0; ts_len as usize];
+        file.read_exact(&mut ts_buf).await?;
+        let max_timestamp = Timestamp::deserialize(ts_buf)?;
+        Ok(Self {
+            path,
+            max_offset,
+            max_timestamp,
+        })
+    }
+
+    pub fn path(&self) -> &Path {
+        self.path.as_path()
+    }
+
+    pub fn max_timestamp(&self) -> Timestamp {
+        self.max_timestamp
+    }
+
+    pub async fn read_events(&self, ts: Timestamp) -> Result<ResultStream<Vec<Event>>> {
+        SegmentStream::open(&self.path, self.max_offset, Some(ts)).await
+    }
+}

--- a/src/journal/src/file/segment_stream.rs
+++ b/src/journal/src/file/segment_stream.rs
@@ -1,0 +1,105 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::path::Path;
+
+use futures::stream;
+use tokio::{fs::File, io::AsyncReadExt};
+
+use crate::{Error, Event, Result, ResultStream, Timestamp};
+
+pub struct SegmentStream {
+    file: File,
+    offset: u64,
+    max_offset: u64,
+    start_event: Option<Event>,
+}
+
+impl SegmentStream {
+    pub async fn open(
+        path: impl AsRef<Path>,
+        limit: u64,
+        start_ts: Option<Timestamp>,
+    ) -> Result<ResultStream<Vec<Event>>> {
+        let file = File::open(path).await?;
+        let mut stream = Self {
+            file,
+            offset: 0,
+            max_offset: limit,
+            start_event: None,
+        };
+
+        // Seeks to the start event.
+        if let Some(ts) = start_ts {
+            while let Some(event) = stream.read_event().await? {
+                if event.ts >= ts {
+                    stream.start_event = Some(event);
+                    break;
+                }
+            }
+        }
+
+        let stream = stream::unfold(stream, |mut stream| async move {
+            stream.next_events().await.map(|events| (events, stream))
+        });
+        Ok(Box::pin(stream))
+    }
+
+    async fn read_event(&mut self) -> Result<Option<Event>> {
+        if self.offset == self.max_offset {
+            return Ok(None);
+        }
+        self.offset += 8;
+        if self.offset > self.max_offset {
+            return Err(Error::Corrupted(format!(
+                "offset {} > max_offset {}",
+                self.offset, self.max_offset
+            )));
+        }
+        if self.offset == self.max_offset {
+            return Ok(None);
+        }
+        let ts_len = self.file.read_u32().await?;
+        let data_len = self.file.read_u32().await?;
+        self.offset += (ts_len + data_len) as u64;
+        if self.offset > self.max_offset {
+            return Err(Error::Corrupted(format!(
+                "offset {} > max_offset {}",
+                self.offset, self.max_offset
+            )));
+        }
+        let mut ts_buf = vec![0; ts_len as usize];
+        self.file.read_exact(&mut ts_buf).await?;
+        let ts = Timestamp::deserialize(ts_buf)?;
+        let mut data = vec![0; data_len as usize];
+        self.file.read_exact(&mut data).await?;
+        Ok(Some(Event { ts, data }))
+    }
+
+    async fn next_event(&mut self) -> Result<Option<Event>> {
+        if let Some(event) = self.start_event.take() {
+            Ok(Some(event))
+        } else {
+            self.read_event().await
+        }
+    }
+
+    async fn next_events(&mut self) -> Option<Result<Vec<Event>>> {
+        match self.next_event().await {
+            Ok(Some(event)) => Some(Ok(vec![event])),
+            Ok(None) => None,
+            Err(err) => Some(Err(err)),
+        }
+    }
+}

--- a/src/journal/src/file/stream.rs
+++ b/src/journal/src/file/stream.rs
@@ -1,0 +1,140 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{path::PathBuf, sync::Arc};
+
+use futures::{future, stream, StreamExt};
+use tokio::{fs, sync::Mutex};
+
+use super::{segment::Segment, segment_reader::SegmentReader};
+use crate::{async_trait, Error, Event, Result, ResultStream, Timestamp};
+
+#[derive(Clone)]
+pub struct Stream {
+    inner: Arc<Mutex<Inner>>,
+}
+
+#[derive(Default)]
+pub struct Inner {
+    path: PathBuf,
+    segment_size: u64,
+    active_segment: Option<Segment>,
+    sealed_segments: Vec<SegmentReader>,
+}
+
+const ACTIVE_SEGMENT: &str = "CURRENT";
+
+impl Inner {
+    fn active_segment_path(&self) -> PathBuf {
+        self.path.join(ACTIVE_SEGMENT)
+    }
+
+    fn sealed_segment_path(&self, ts: Timestamp) -> PathBuf {
+        self.path.join(format!("{:?}", ts))
+    }
+}
+
+impl Stream {
+    pub async fn open(path: PathBuf, segment_size: u64) -> Result<Stream> {
+        let mut inner = Inner {
+            path,
+            segment_size,
+            active_segment: None,
+            sealed_segments: Vec::new(),
+        };
+
+        // Opens all sealed segments and sorts them by timestamp.
+        let mut entries = fs::read_dir(&inner.path).await?;
+        while let Some(ent) = entries.next_entry().await? {
+            if ent.file_name() != ACTIVE_SEGMENT {
+                let segment = SegmentReader::open(ent.path()).await?;
+                inner.sealed_segments.push(segment);
+            }
+        }
+        inner.sealed_segments.sort_by_key(|x| x.max_timestamp());
+
+        let last_timestamp = inner.sealed_segments.last().map(|x| x.max_timestamp());
+        let active = Segment::open(inner.active_segment_path(), last_timestamp).await?;
+        inner.active_segment = Some(active);
+
+        Ok(Stream {
+            inner: Arc::new(Mutex::new(inner)),
+        })
+    }
+
+    async fn read_segments(&self, ts: Timestamp) -> Result<Vec<ResultStream<Vec<Event>>>> {
+        let inner = self.inner.lock().await;
+        let index = inner
+            .sealed_segments
+            .partition_point(|x| x.max_timestamp() < ts);
+        let mut streams = Vec::new();
+        for segment in &inner.sealed_segments[index..] {
+            streams.push(segment.read_events(ts).await?);
+        }
+        if let Some(segment) = &inner.active_segment {
+            streams.push(segment.read_events(ts).await?);
+        }
+        Ok(streams)
+    }
+}
+
+#[async_trait]
+impl crate::Stream for Stream {
+    async fn read_events(&self, ts: Timestamp) -> ResultStream<Vec<Event>> {
+        match self.read_segments(ts).await {
+            Ok(streams) => Box::pin(stream::iter(streams).flatten()),
+            Err(err) => Box::pin(stream::once(future::err(err))),
+        }
+    }
+
+    async fn append_event(&self, event: Event) -> Result<()> {
+        let mut inner = self.inner.lock().await;
+        let size = if let Some(active) = inner.active_segment.as_mut() {
+            active.append_event(event).await?
+        } else {
+            return Err(Error::Unknown(
+                "active segment is closed due to previous errors".to_owned(),
+            ));
+        };
+
+        if size >= inner.segment_size {
+            // Seals the active segment.
+            let active = inner.active_segment.take().unwrap();
+            let last_timestamp = active.seal().await?;
+
+            // Renames the active segment to a sealed segment.
+            let active_segment_path = inner.active_segment_path();
+            let sealed_segment_path = inner.sealed_segment_path(last_timestamp);
+            fs::rename(&active_segment_path, &sealed_segment_path).await?;
+            let sealed = SegmentReader::open(sealed_segment_path).await?;
+            inner.sealed_segments.push(sealed);
+
+            // Opens a new active segment.
+            let active = Segment::open(&active_segment_path, Some(last_timestamp)).await?;
+            inner.active_segment = Some(active);
+        }
+        Ok(())
+    }
+
+    async fn release_events(&self, ts: Timestamp) -> Result<()> {
+        let mut inner = self.inner.lock().await;
+        let index = inner
+            .sealed_segments
+            .partition_point(|x| x.max_timestamp() < ts);
+        for segment in inner.sealed_segments.drain(..index) {
+            fs::remove_file(segment.path()).await?;
+        }
+        Ok(())
+    }
+}

--- a/src/journal/src/grpc/error.rs
+++ b/src/journal/src/grpc/error.rs
@@ -32,6 +32,8 @@ impl From<Error> for tonic::Status {
             Error::NotFound(s) => (tonic::Code::NotFound, s),
             Error::AlreadyExists(s) => (tonic::Code::AlreadyExists, s),
             Error::InvalidArgument(s) => (tonic::Code::InvalidArgument, s),
+            Error::Io(err) => (tonic::Code::Unknown, err.to_string()),
+            Error::Corrupted(s) => (tonic::Code::Unknown, s),
             Error::Unknown(s) => (tonic::Code::Unknown, s),
         };
         tonic::Status::new(code, message)

--- a/src/journal/src/grpc/stream.rs
+++ b/src/journal/src/grpc/stream.rs
@@ -43,7 +43,7 @@ impl crate::Stream for Stream {
     async fn read_events(&self, ts: Timestamp) -> ResultStream<Vec<Event>> {
         let output = self.read_events_internal(ts).await;
         match output {
-            Ok(output) => Box::new(output.map(|result| match result {
+            Ok(output) => Box::pin(output.map(|result| match result {
                 Ok(resp) => {
                     let events: Result<Vec<Event>> = resp
                         .events
@@ -59,7 +59,7 @@ impl crate::Stream for Stream {
                 }
                 Err(status) => Err(Error::from(status)),
             })),
-            Err(e) => Box::new(futures::stream::once(futures::future::err(e))),
+            Err(e) => Box::pin(futures::stream::once(futures::future::err(e))),
         }
     }
 

--- a/src/journal/src/journal.rs
+++ b/src/journal/src/journal.rs
@@ -31,6 +31,8 @@ pub trait Journal: Clone + Send + Sync + 'static {
 
     /// Deletes a stream.
     ///
+    /// Using a deleted stream is an undefined behavior.
+    ///
     /// # Errors
     ///
     /// Returns `Error::NotFound` if the stream doesn't exist.

--- a/src/journal/src/lib.rs
+++ b/src/journal/src/lib.rs
@@ -24,6 +24,7 @@
 //! Some built-in implementations of [`Journal`]:
 //!
 //! - [`mem`](crate::mem)
+//! - [`file`](crate::file)
 //! - [`grpc`](crate::grpc)
 //!
 //! [`Journal`]: crate::Journal
@@ -32,12 +33,13 @@ mod error;
 mod journal;
 mod stream;
 
+pub mod file;
 pub mod grpc;
 pub mod mem;
 
 pub use async_trait::async_trait;
 
-pub type ResultStream<T> = Box<dyn futures::Stream<Item = Result<T>> + Send + Unpin>;
+pub type ResultStream<T> = futures::stream::BoxStream<'static, Result<T>>;
 
 pub use self::{
     error::{Error, Result},

--- a/src/journal/src/mem/stream.rs
+++ b/src/journal/src/mem/stream.rs
@@ -37,7 +37,7 @@ impl crate::Stream for Stream {
     async fn read_events(&self, ts: Timestamp) -> ResultStream<Vec<Event>> {
         let events = self.events.lock().await;
         let offset = events.partition_point(|x| x.ts < ts);
-        Box::new(stream::once(future::ok(
+        Box::pin(stream::once(future::ok(
             events.range(offset..).cloned().collect(),
         )))
     }

--- a/src/journal/src/stream.rs
+++ b/src/journal/src/stream.rs
@@ -17,7 +17,7 @@ use std::convert::TryInto;
 use crate::{async_trait, Error, Result, ResultStream};
 
 /// A generic timestamp to order events.
-#[derive(Copy, Clone, Debug, PartialEq, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub struct Timestamp(u64);
 
 impl Timestamp {

--- a/src/kernel/src/error.rs
+++ b/src/kernel/src/error.rs
@@ -28,6 +28,8 @@ pub enum Error {
     Internal(String),
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    #[error("{0}")]
+    Corrupted(String),
     #[error(transparent)]
     Unknown(Box<dyn std::error::Error + Send>),
 }
@@ -44,6 +46,8 @@ impl From<JournalError> for Error {
             JournalError::NotFound(s) => Self::NotFound(s),
             JournalError::AlreadyExists(s) => Self::AlreadyExists(s),
             JournalError::InvalidArgument(s) => Self::InvalidArgument(s),
+            JournalError::Io(err) => Self::Io(err),
+            JournalError::Corrupted(s) => Self::Corrupted(s),
             err @ JournalError::Unknown(_) => Self::Unknown(Box::new(err)),
         }
     }

--- a/src/kernel/src/grpc/error.rs
+++ b/src/kernel/src/grpc/error.rs
@@ -34,6 +34,7 @@ impl From<Error> for tonic::Status {
             Error::InvalidArgument(s) => (tonic::Code::InvalidArgument, s),
             Error::Internal(s) => (tonic::Code::Internal, s),
             Error::Io(inner) => (tonic::Code::Internal, inner.to_string()),
+            Error::Corrupted(s) => (tonic::Code::DataLoss, s),
             Error::Unknown(s) => (tonic::Code::Unknown, s.to_string()),
         };
         tonic::Status::new(code, message)


### PR DESCRIPTION
See #128 for some discussions. No memory index so far for simplicity. The implementation is not very reliable on failures (so many corner cases) and only some intuitive tests are added. BTW, I think the Journal/Storage interfaces are still subject to significant refactor in the next release. So this PR simply provides a usable implementation for v0.2 and doesn't aim to be thorough by any means.

Journal file layout in this PR:

```
- journal_root
  - stream_root
    - active_stream (CURRENT)
    - sealed_stream_1
    - sealed_stream_2
    - ...
```


Closes #128 , closes #65 