### PR TITLE
kernel: add a file implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,7 @@ dependencies = [
  "engula-storage",
  "futures",
  "prost",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -19,5 +19,8 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 tonic = "0.6"
 prost = "0.9"
 
+[dev-dependencies]
+tempfile = "3"
+
 [build-dependencies]
 tonic-build = "0.6"

--- a/src/kernel/src/file/kernel.rs
+++ b/src/kernel/src/file/kernel.rs
@@ -12,16 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::path::Path;
+
 use super::{manifest::Manifest, Journal, Storage};
 use crate::Result;
 
 pub type Kernel = crate::local::Kernel<Journal, Storage, Manifest>;
 
+const SEGMENT_SIZE: usize = 64 * 1024 * 1024;
+
 impl Kernel {
-    pub async fn open() -> Result<Self> {
-        let journal = Journal::default();
-        let storage = Storage::default();
-        let manifest = Manifest::default();
+    pub async fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let journal_path = path.join("journal");
+        let storage_path = path.join("storage");
+        let manifest_path = path.join("MANIFEST");
+        let journal = Journal::open(journal_path, SEGMENT_SIZE).await?;
+        let storage = Storage::new(storage_path).await?;
+        let manifest = Manifest::open(manifest_path).await;
         Self::init(journal, storage, manifest).await
     }
 }

--- a/src/kernel/src/file/manifest.rs
+++ b/src/kernel/src/file/manifest.rs
@@ -1,0 +1,66 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{io::ErrorKind, path::PathBuf};
+
+use prost::Message;
+use tokio::{
+    fs::{File, OpenOptions},
+    io::{AsyncReadExt, AsyncWriteExt},
+};
+
+use crate::{async_trait, Error, Result, Version};
+
+#[derive(Clone)]
+pub struct Manifest {
+    path: PathBuf,
+}
+
+impl Manifest {
+    pub async fn open(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+}
+
+#[async_trait]
+impl crate::manifest::Manifest for Manifest {
+    async fn load_version(&self) -> Result<Version> {
+        let mut buf = Vec::new();
+        match File::open(&self.path).await {
+            Ok(mut file) => {
+                file.read_to_end(&mut buf).await?;
+                Version::decode(buf.as_ref()).map_err(|err| Error::Corrupted(err.to_string()))
+            }
+            Err(err) => {
+                if err.kind() == ErrorKind::NotFound {
+                    Ok(Version::default())
+                } else {
+                    Err(err.into())
+                }
+            }
+        }
+    }
+
+    async fn save_version(&self, version: &Version) -> Result<()> {
+        let buf = version.encode_to_vec();
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&self.path)
+            .await?;
+        file.write_buf(&mut buf.as_ref()).await?;
+        file.sync_data().await?;
+        Ok(())
+    }
+}

--- a/src/kernel/src/file/manifest.rs
+++ b/src/kernel/src/file/manifest.rs
@@ -57,6 +57,7 @@ impl crate::manifest::Manifest for Manifest {
         let mut file = OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(true)
             .open(&self.path)
             .await?;
         file.write_buf(&mut buf.as_ref()).await?;

--- a/src/kernel/src/file/mod.rs
+++ b/src/kernel/src/file/mod.rs
@@ -12,16 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{manifest::Manifest, Journal, Storage};
-use crate::Result;
+//! A [`Kernel`] implementation that stores everything in memory.
+//!
+//! [`Kernel`]: crate::Kernel
 
-pub type Kernel = crate::local::Kernel<Journal, Storage, Manifest>;
+mod kernel;
+mod manifest;
 
-impl Kernel {
-    pub async fn open() -> Result<Self> {
-        let journal = Journal::default();
-        let storage = Storage::default();
-        let manifest = Manifest::default();
-        Self::init(journal, storage, manifest).await
-    }
-}
+pub use engula_journal::file::Journal;
+pub use engula_storage::file::Storage;
+
+pub use self::{kernel::Kernel, manifest::Manifest};

--- a/src/kernel/src/file/mod.rs
+++ b/src/kernel/src/file/mod.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! A [`Kernel`] implementation that stores everything in memory.
+//! A [`Kernel`] implementation that stores everything in local files.
 //!
 //! [`Kernel`]: crate::Kernel
 

--- a/src/kernel/src/lib.rs
+++ b/src/kernel/src/lib.rs
@@ -25,6 +25,8 @@
 //! Some built-in implementations of [`Kernel`]:
 //!
 //! - [`mem`](crate::mem)
+//! - [`file`](crate::file)
+//! - [`grpc`](crate::grpc)
 //!
 //! [`Kernel`]: crate::Kernel
 
@@ -33,13 +35,14 @@ mod kernel;
 mod manifest;
 mod metadata;
 
+pub mod file;
 pub mod grpc;
 mod local;
 pub mod mem;
 
 pub use async_trait::async_trait;
-pub use engula_journal::{Event, Stream, Timestamp};
-pub use engula_storage::Bucket;
+pub use engula_journal::{Event, Journal, Stream, Timestamp};
+pub use engula_storage::{Bucket, Storage};
 
 pub type ResultStream<T> = Box<dyn futures::Stream<Item = Result<T>> + Send + Unpin>;
 
@@ -48,3 +51,51 @@ pub use self::{
     kernel::{Kernel, KernelUpdate},
     metadata::{Sequence, Version, VersionUpdate},
 };
+
+#[cfg(test)]
+mod tests {
+    use futures::TryStreamExt;
+
+    use crate::*;
+
+    #[tokio::test]
+    async fn kernel() -> Result<()> {
+        let tmp = tempfile::tempdir()?;
+
+        let kernel = mem::Kernel::open().await?;
+        test_kernel(kernel).await?;
+
+        let kernel = file::Kernel::open(tmp.path()).await?;
+        test_kernel(kernel).await?;
+
+        Ok(())
+    }
+
+    async fn test_kernel(kernel: impl Kernel) -> Result<()> {
+        let handle = {
+            let mut expect = VersionUpdate {
+                sequence: 1,
+                ..Default::default()
+            };
+            expect.add_meta.insert("a".to_owned(), b"b".to_vec());
+            expect.remove_meta.push("b".to_owned());
+            expect.add_objects.push("a".to_owned());
+            expect.remove_objects.push("b".to_owned());
+            let mut version_updates = kernel.version_updates(0).await;
+            tokio::spawn(async move {
+                let update = version_updates.try_next().await.unwrap().unwrap();
+                assert_eq!(*update, expect);
+            })
+        };
+
+        let mut update = KernelUpdate::default();
+        update.add_meta("a", "b");
+        update.remove_meta("b");
+        update.add_object("a");
+        update.remove_object("b");
+        kernel.apply_update(update).await?;
+
+        handle.await.unwrap();
+        Ok(())
+    }
+}

--- a/src/kernel/src/mem/mod.rs
+++ b/src/kernel/src/mem/mod.rs
@@ -19,45 +19,7 @@
 mod kernel;
 mod manifest;
 
-pub use engula_journal::mem::Stream;
-pub use engula_storage::mem::Bucket;
+pub use engula_journal::mem::Journal;
+pub use engula_storage::mem::Storage;
 
 pub use self::{kernel::Kernel, manifest::Manifest};
-
-#[cfg(test)]
-mod tests {
-    use futures::TryStreamExt;
-
-    use crate::*;
-
-    #[tokio::test]
-    async fn update() -> Result<()> {
-        let kernel = super::Kernel::open().await?;
-
-        let handle = {
-            let mut expect = VersionUpdate {
-                sequence: 1,
-                ..Default::default()
-            };
-            expect.add_meta.insert("a".to_owned(), b"b".to_vec());
-            expect.remove_meta.push("b".to_owned());
-            expect.add_objects.push("a".to_owned());
-            expect.remove_objects.push("b".to_owned());
-            let mut version_updates = kernel.version_updates(0).await;
-            tokio::spawn(async move {
-                let update = version_updates.try_next().await.unwrap().unwrap();
-                assert_eq!(*update, expect);
-            })
-        };
-
-        let mut update = KernelUpdate::default();
-        update.add_meta("a", "b");
-        update.remove_meta("b");
-        update.add_object("a");
-        update.remove_object("b");
-        kernel.apply_update(update).await?;
-
-        handle.await.unwrap();
-        Ok(())
-    }
-}


### PR DESCRIPTION
Closes #147 .

Refactor the local kernel to hold Journal/Storage and create stream/bucket internally.
The file manifest implementation is very naive, though.