### PR TITLE
ci: always run cargo install cargo-audit

### DIFF
--- a/.github/workflows/audit-security.yml
+++ b/.github/workflows/audit-security.yml
@@ -32,7 +32,6 @@ jobs:
   audit-security:
     name: Audit Security
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'skip audit')"
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/audit-security.yml
+++ b/.github/workflows/audit-security.yml
@@ -41,7 +41,6 @@ jobs:
         uses: ./.github/actions/cargo-cache
 
       - name: Install cargo-audit
-        if: steps.cache.outputs.cache-hit != 'true'
         uses: actions-rs/cargo@v1
         with:
           command: install


### PR DESCRIPTION
`cargo` already handles cache if there is one.

This closes #188.

Signed-off-by: tison <wander4096@gmail.com>

Verified
* cache miss: https://github.com/tisonkun/engula/runs/4541804122?check_suite_focus=true
* cache hit: https://github.com/tisonkun/engula/runs/4541832408?check_suite_focus=true