### PR TITLE
luna: add table/block builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,6 @@ name = "luna-engine"
 version = "0.3.0"
 dependencies = [
  "bytes",
- "futures",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,9 @@ dependencies = [
 name = "luna-engine"
 version = "0.3.0"
 dependencies = [
+ "bytes",
+ "futures",
+ "tempfile",
  "thiserror",
  "tokio",
 ]

--- a/src/engine/luna/Cargo.toml
+++ b/src/engine/luna/Cargo.toml
@@ -8,5 +8,10 @@ repository = "https://github.com/engula/engula"
 description = "A transactional key-value storage engine."
 
 [dependencies]
+bytes = "1.1.0"
+futures = "0.3.17"
 thiserror = "1.0.3"
 tokio = { version = "1.15.0", features = ["full"] }
+
+[dev-dependencies]
+tempfile = "3.2.0"

--- a/src/engine/luna/Cargo.toml
+++ b/src/engine/luna/Cargo.toml
@@ -9,7 +9,6 @@ description = "A transactional key-value storage engine."
 
 [dependencies]
 bytes = "1.1.0"
-futures = "0.3.17"
 thiserror = "1.0.3"
 tokio = { version = "1.15.0", features = ["full"] }
 

--- a/src/engine/luna/src/error.rs
+++ b/src/engine/luna/src/error.rs
@@ -16,12 +16,12 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("{0} doesn't exist")]
-    NotFound(String),
     #[error("{0} already exists")]
     AlreadyExists(String),
     #[error("{0}")]
     InvalidArgument(String),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/engine/luna/src/lib.rs
+++ b/src/engine/luna/src/lib.rs
@@ -15,6 +15,7 @@
 mod collection;
 mod database;
 mod error;
+mod table;
 
 pub use self::{
     collection::Collection,

--- a/src/engine/luna/src/table/block_builder.rs
+++ b/src/engine/luna/src/table/block_builder.rs
@@ -1,0 +1,83 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::mem::size_of;
+
+use bytes::BufMut;
+
+// Block format:
+//
+// Block = { Entry } Footer
+//
+// Entry format:
+//   key size   : fixed32
+//   value size : fixed32
+//   key        : key size
+//   value      : value size
+//
+// Footer format:
+//   restarts     : fixed32 * num_restarts
+//   num_restarts : fixed32
+
+pub struct BlockBuilder {
+    buf: Vec<u8>,
+    restarts: Vec<u32>,
+    num_entries: u32,
+    restart_interval: u32,
+}
+
+impl BlockBuilder {
+    pub fn new(restart_interval: u32) -> Self {
+        Self {
+            buf: Vec::new(),
+            restarts: Vec::new(),
+            num_entries: 0,
+            restart_interval,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.buf.clear();
+        self.restarts.clear();
+        self.num_entries = 0;
+    }
+
+    pub fn add(&mut self, key: &[u8], value: &[u8]) {
+        if self.num_entries % self.restart_interval == 0 {
+            self.restarts.push(self.buf.len() as u32);
+        }
+
+        self.buf.put_u32(key.len() as u32);
+        self.buf.put_u32(value.len() as u32);
+        self.buf.put_slice(key);
+        self.buf.put_slice(value);
+        self.num_entries += 1;
+    }
+
+    pub fn finish(&mut self) -> &[u8] {
+        for restart in &self.restarts {
+            self.buf.put_u32(*restart);
+        }
+        self.buf.put_u32(self.restarts.len() as u32);
+        &self.buf
+    }
+
+    pub fn num_entries(&self) -> u32 {
+        self.num_entries
+    }
+
+    pub fn estimated_size(&self) -> u32 {
+        (self.buf.len() + self.restarts.len() * size_of::<u32>() + size_of::<u32>()) as u32
+    }
+}

--- a/src/engine/luna/src/table/block_handle.rs
+++ b/src/engine/luna/src/table/block_handle.rs
@@ -1,0 +1,48 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::{Buf, BufMut};
+
+// BlockHandle format:
+//   offset : fixed64
+//   length : fixed64
+
+pub struct BlockHandle {
+    pub offset: u64,
+    pub length: u64,
+}
+
+impl BlockHandle {
+    pub fn new(offset: u64, length: u64) -> Self {
+        Self { offset, length }
+    }
+
+    pub fn encode_to(&self, buf: &mut impl BufMut) {
+        buf.put_u64(self.offset);
+        buf.put_u64(self.length);
+    }
+
+    pub fn encode_to_vec(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(16);
+        self.encode_to(&mut buf);
+        buf
+    }
+
+    #[allow(dead_code)]
+    pub fn decode_from(buf: &mut impl Buf) -> Self {
+        let offset = buf.get_u64();
+        let length = buf.get_u64();
+        Self { offset, length }
+    }
+}

--- a/src/engine/luna/src/table/mod.rs
+++ b/src/engine/luna/src/table/mod.rs
@@ -1,0 +1,40 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod block_builder;
+mod block_handle;
+mod table_builder;
+
+pub use self::table_builder::{TableBuilder, TableBuilderOptions};
+
+#[cfg(test)]
+mod tests {
+    use tokio::fs::File;
+
+    use super::*;
+    use crate::Result;
+
+    #[tokio::test]
+    async fn table() -> Result<()> {
+        let file = tempfile::tempfile()?;
+        let options = TableBuilderOptions::default();
+        let mut builder = TableBuilder::new(options, File::from_std(file));
+        for i in 0..1024u64 {
+            let k = i.to_be_bytes();
+            builder.add(&k, &k).await?;
+        }
+        builder.finish().await?;
+        Ok(())
+    }
+}

--- a/src/engine/luna/src/table/table_builder.rs
+++ b/src/engine/luna/src/table/table_builder.rs
@@ -1,0 +1,117 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+
+use super::{block_builder::BlockBuilder, block_handle::BlockHandle};
+use crate::Result;
+
+// Table format:
+//
+// Table = { DataBlock } IndexBlock TableFooter
+// DataBlock = Block
+// IndexBlock = Block
+//
+// TableFooter format:
+//   index block handle : BlockHandle
+
+pub struct TableBuilderOptions {
+    block_size: u32,
+    block_restart_interval: u32,
+}
+
+impl Default for TableBuilderOptions {
+    fn default() -> Self {
+        Self {
+            block_size: 4096,
+            block_restart_interval: 16,
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub struct TableBuilder<W> {
+    options: TableBuilderOptions,
+    last_key: Vec<u8>,
+    table_writer: TableWriter<W>,
+    data_block_builder: BlockBuilder,
+    index_block_builder: BlockBuilder,
+}
+
+#[allow(dead_code)]
+impl<W: AsyncWrite + Unpin> TableBuilder<W> {
+    pub fn new(options: TableBuilderOptions, writer: W) -> Self {
+        let data_block_builder = BlockBuilder::new(options.block_restart_interval);
+        let index_block_builder = BlockBuilder::new(1);
+        Self {
+            options,
+            last_key: Vec::new(),
+            table_writer: TableWriter::new(writer),
+            data_block_builder,
+            index_block_builder,
+        }
+    }
+
+    pub async fn add(&mut self, key: &[u8], value: &[u8]) -> Result<()> {
+        self.last_key = key.to_owned();
+        self.data_block_builder.add(key, value);
+        if self.data_block_builder.estimated_size() >= self.options.block_size {
+            self.finish_data_block().await?;
+        }
+        Ok(())
+    }
+
+    pub async fn finish(mut self) -> Result<()> {
+        self.finish_data_block().await?;
+        let block = self.index_block_builder.finish();
+        let handle = self.table_writer.write(block).await?;
+        self.table_writer.write(&handle.encode_to_vec()).await?;
+        self.table_writer.close().await?;
+        Ok(())
+    }
+
+    async fn finish_data_block(&mut self) -> Result<()> {
+        if self.data_block_builder.num_entries() > 0 {
+            let block = self.data_block_builder.finish();
+            let handle = self.table_writer.write(block).await?;
+            self.data_block_builder.reset();
+            self.index_block_builder
+                .add(&self.last_key, &handle.encode_to_vec());
+        }
+        Ok(())
+    }
+}
+
+struct TableWriter<W> {
+    writer: W,
+    offset: u64,
+}
+
+impl<W: AsyncWrite + Unpin> TableWriter<W> {
+    fn new(writer: W) -> Self {
+        Self { writer, offset: 0 }
+    }
+
+    async fn write(&mut self, data: &[u8]) -> Result<BlockHandle> {
+        let handle = BlockHandle::new(self.offset, data.len() as u64);
+        self.writer.write_all(data).await?;
+        self.offset += data.len() as u64;
+        Ok(handle)
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.writer.shutdown().await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Use a simplified encoding from LevelDB/RocksDB. For example, things like prefix compression are not implemented.