### PR TITLE
luna: add iterators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,9 +205,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -230,15 +230,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -247,18 +247,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -266,23 +264,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -292,8 +289,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -503,6 +498,7 @@ name = "luna-engine"
 version = "0.3.0"
 dependencies = [
  "bytes",
+ "futures",
  "tempfile",
  "thiserror",
  "tokio",
@@ -678,18 +674,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"

--- a/src/engine/luna/Cargo.toml
+++ b/src/engine/luna/Cargo.toml
@@ -9,6 +9,7 @@ description = "A transactional key-value storage engine."
 
 [dependencies]
 bytes = "1.1.0"
+futures = "0.3.19"
 thiserror = "1.0.3"
 tokio = { version = "1.15.0", features = ["full"] }
 

--- a/src/engine/luna/src/table/iter.rs
+++ b/src/engine/luna/src/table/iter.rs
@@ -1,0 +1,77 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    ops::DerefMut,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use crate::Result;
+
+pub type BoxIter = Pin<Box<dyn Iter>>;
+
+pub trait Iter {
+    fn poll_seek_to_first(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>>;
+
+    fn poll_seek(self: Pin<&mut Self>, cx: &mut Context<'_>, target: &[u8]) -> Poll<Result<()>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>>;
+
+    fn current(&self) -> Option<(&[u8], &[u8])>;
+}
+
+impl<I: ?Sized + Iter + Unpin> Iter for Box<I> {
+    fn poll_seek_to_first(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        Pin::new(&mut **self).poll_seek_to_first(cx)
+    }
+
+    fn poll_seek(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        target: &[u8],
+    ) -> Poll<Result<()>> {
+        Pin::new(&mut **self).poll_seek(cx, target)
+    }
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        Pin::new(&mut **self).poll_next(cx)
+    }
+
+    fn current(&self) -> Option<(&[u8], &[u8])> {
+        (**self).current()
+    }
+}
+
+impl<P> Iter for Pin<P>
+where
+    P: DerefMut + Unpin,
+    P::Target: Iter,
+{
+    fn poll_seek_to_first(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.get_mut().as_mut().poll_seek_to_first(cx)
+    }
+
+    fn poll_seek(self: Pin<&mut Self>, cx: &mut Context<'_>, target: &[u8]) -> Poll<Result<()>> {
+        self.get_mut().as_mut().poll_seek(cx, target)
+    }
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.get_mut().as_mut().poll_next(cx)
+    }
+
+    fn current(&self) -> Option<(&[u8], &[u8])> {
+        (**self).current()
+    }
+}

--- a/src/engine/luna/src/table/merging_iter.rs
+++ b/src/engine/luna/src/table/merging_iter.rs
@@ -1,0 +1,114 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd},
+    collections::BinaryHeap,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::ready;
+
+use super::iter::{BoxIter, Iter};
+use crate::Result;
+
+pub struct MergingIter {
+    children: Vec<BoxIter>,
+    heap: BinaryHeap<BoxIter>,
+}
+
+#[allow(dead_code)]
+impl MergingIter {
+    pub fn new(children: Vec<BoxIter>) -> Self {
+        Self {
+            children,
+            heap: BinaryHeap::new(),
+        }
+    }
+
+    fn take_children(&mut self) -> Vec<BoxIter> {
+        if !self.children.is_empty() {
+            std::mem::take(&mut self.children)
+        } else {
+            let heap = std::mem::take(&mut self.heap);
+            heap.into_vec()
+        }
+    }
+}
+
+impl Iter for MergingIter {
+    fn poll_seek_to_first(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        let mut children = self.take_children();
+        for child in &mut children {
+            ready!(Pin::new(child).poll_seek_to_first(cx))?;
+        }
+        self.heap = BinaryHeap::from(children);
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_seek(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        target: &[u8],
+    ) -> Poll<Result<()>> {
+        let mut children = self.take_children();
+        for child in &mut children {
+            ready!(Pin::new(child).poll_seek(cx, target))?;
+        }
+        self.heap = BinaryHeap::from(children);
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        if let Some(mut first) = self.heap.pop() {
+            ready!(Pin::new(&mut first).poll_next(cx))?;
+            self.heap.push(first);
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn current(&self) -> Option<(&[u8], &[u8])> {
+        self.heap.peek().and_then(|x| x.current())
+    }
+}
+
+impl Eq for dyn Iter {}
+
+impl PartialEq for dyn Iter {
+    fn eq(&self, other: &Self) -> bool {
+        match (self.current(), other.current()) {
+            (Some(a), Some(b)) => a.0 == b.0,
+            (None, None) => true,
+            _ => false,
+        }
+    }
+}
+
+impl Ord for dyn Iter {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self.current(), other.current()) {
+            (Some(a), Some(b)) => b.0.cmp(a.0),
+            (Some(_), None) => Ordering::Greater,
+            (None, Some(_)) => Ordering::Less,
+            (None, None) => Ordering::Equal,
+        }
+    }
+}
+
+impl PartialOrd for dyn Iter {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}

--- a/src/engine/luna/src/table/mod.rs
+++ b/src/engine/luna/src/table/mod.rs
@@ -17,6 +17,7 @@ mod block_handle;
 mod iter;
 mod merging_iter;
 mod table_builder;
+mod two_level_iter;
 
 pub use self::table_builder::{TableBuilder, TableBuilderOptions};
 

--- a/src/engine/luna/src/table/mod.rs
+++ b/src/engine/luna/src/table/mod.rs
@@ -14,6 +14,8 @@
 
 mod block_builder;
 mod block_handle;
+mod iter;
+mod merging_iter;
 mod table_builder;
 
 pub use self::table_builder::{TableBuilder, TableBuilderOptions};

--- a/src/engine/luna/src/table/two_level_iter.rs
+++ b/src/engine/luna/src/table/two_level_iter.rs
@@ -1,0 +1,122 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::ready;
+
+use super::iter::Iter;
+use crate::Result;
+
+pub trait IterGen {
+    type Iter: Iter + Unpin;
+
+    fn poll_gen(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        value: &[u8],
+    ) -> Poll<Result<Self::Iter>>;
+}
+
+pub struct TwoLevelIter<I: Iter, G: IterGen> {
+    first_iter: I,
+    second_iter: Option<G::Iter>,
+    second_iter_gen: G,
+}
+
+impl<I: Iter + Unpin, G: IterGen + Unpin> TwoLevelIter<I, G> {
+    fn borrow_fields(&mut self) -> (&I, &mut G) {
+        (&self.first_iter, &mut self.second_iter_gen)
+    }
+
+    fn init_second_iter(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        let (first_iter, second_iter_gen) = self.borrow_fields();
+        if first_iter.valid() {
+            let value = first_iter.value();
+            let second_iter = ready!(Pin::new(second_iter_gen).poll_gen(cx, value))?;
+            self.second_iter = Some(second_iter);
+        } else {
+            self.second_iter = None;
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn skip_until_valid(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        while let Some(iter) = self.second_iter.as_ref() {
+            if iter.valid() {
+                break;
+            }
+            ready!(Pin::new(&mut self.first_iter).poll_next(cx))?;
+            ready!(self.as_mut().init_second_iter(cx))?;
+        }
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl<I, G> Iter for TwoLevelIter<I, G>
+where
+    I: Iter + Unpin,
+    G: IterGen + Unpin,
+{
+    fn poll_seek_to_first(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        ready!(Pin::new(&mut self.first_iter).poll_seek_to_first(cx))?;
+        ready!(self.as_mut().init_second_iter(cx))?;
+        if let Some(iter) = self.second_iter.as_mut() {
+            ready!(Pin::new(iter).poll_seek_to_first(cx))?;
+            ready!(self.skip_until_valid(cx))?;
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_seek(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        target: &[u8],
+    ) -> Poll<Result<()>> {
+        ready!(Pin::new(&mut self.first_iter).poll_seek(cx, target))?;
+        ready!(self.as_mut().init_second_iter(cx))?;
+        if let Some(iter) = self.second_iter.as_mut() {
+            ready!(Pin::new(iter).poll_seek(cx, target))?;
+            ready!(self.skip_until_valid(cx))?;
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        if let Some(iter) = self.second_iter.as_mut() {
+            ready!(Pin::new(iter).poll_next(cx))?;
+            ready!(self.skip_until_valid(cx))?;
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn valid(&self) -> bool {
+        if let Some(iter) = self.second_iter.as_ref() {
+            iter.valid()
+        } else {
+            false
+        }
+    }
+
+    fn key(&self) -> &[u8] {
+        self.second_iter.as_ref().unwrap().key()
+    }
+
+    fn value(&self) -> &[u8] {
+        self.second_iter.as_ref().unwrap().value()
+    }
+}


### PR DESCRIPTION
Add `Iter`, `MergintIter`, and `TwoLevelIter`. We need to add a `IterExt` later. These things work similarly to `AsyncRead` and `AsyncReadExt` in the futures crate.