### PR TITLE
ci: turn on some taplo rules to format Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ description = "A serverless storage engine that empowers engineers to build reli
 members = ["src/engine/luna", "src/journal", "src/storage", "src/futures"]
 
 [dependencies]
-luna-engine = { version = "0.3.0", path = "src/engine/luna" }
+engula-futures = { version = "0.3.0", path = "src/futures" }
 engula-journal = { version = "0.3.0", path = "src/journal" }
 engula-storage = { version = "0.3.0", path = "src/storage" }
-engula-futures = { version = "0.3.0", path = "src/futures" }
+luna-engine = { version = "0.3.0", path = "src/engine/luna" }
 
 tokio = { version = "1", features = ["full"] }

--- a/src/engine/hash/Cargo.toml
+++ b/src/engine/hash/Cargo.toml
@@ -8,11 +8,11 @@ repository = "https://github.com/engula/engula"
 description = "An Engula engine that provides simple key-value storage."
 
 [dependencies]
-engula-kernel = { version = "0.3.0", path = "../../kernel" }
 engula-journal = { version = "0.3.0", path = "../../journal" }
+engula-kernel = { version = "0.3.0", path = "../../kernel" }
 engula-storage = { version = "0.3.0", path = "../../storage" }
 
-thiserror = "1.0"
-tokio = { version = "1.14", features = ["full"] }
 bytes = "1.1"
 futures = "0.3"
+thiserror = "1.0"
+tokio = { version = "1.14", features = ["full"] }

--- a/src/journal/Cargo.toml
+++ b/src/journal/Cargo.toml
@@ -10,10 +10,10 @@ description = "An Engula module that provides stream storage abstractions and im
 [dependencies]
 engula-futures = { version = "0.3.0", path = "../futures" }
 
-thiserror = "1.0"
 async-trait = "0.1"
-tokio = { version = "1.13", features = ["full"] }
 prost = "0.9"
+thiserror = "1.0"
+tokio = { version = "1.13", features = ["full"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -8,17 +8,17 @@ repository = "https://github.com/engula/engula"
 description = "An Engula module that provides stateful environment abstractions and implementations."
 
 [dependencies]
+engula-futures = { version = "0.3.0", path = "../futures" }
 engula-journal = { version = "0.3.0", path = "../journal" }
 engula-storage = { version = "0.3.0", path = "../storage" }
-engula-futures = { version = "0.3.0", path = "../futures" }
 
-thiserror = "1.0"
 async-trait = "0.1"
 futures = "0.3"
+prost = "0.9"
+thiserror = "1.0"
 tokio = { version = "1.14", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tonic = "0.6"
-prost = "0.9"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -10,12 +10,12 @@ description = "An Engula module that provides object storage abstractions and im
 [dependencies]
 engula-futures = { version = "0.3.0", path = "../futures" }
 
-thiserror = "1.0"
 async-trait = "0.1"
 bytes = "1.1.0"
-tokio = { version = "1.13", features = ["full"] }
-prost = "0.9"
 futures = "0.3"
+prost = "0.9"
+thiserror = "1.0"
+tokio = { version = "1.13", features = ["full"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,13 @@
+include = ["**/Cargo.toml"]
+
+[formatting]
+array_auto_collapse = true
+array_auto_expand = true
+reorder_keys = true
+
+# Do not sort key names within [package] section.
+[[rule]]
+keys = ["package"]
+
+[rule.formatting]
+reorder_keys = false

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,8 +1,6 @@
 include = ["**/Cargo.toml"]
 
 [formatting]
-array_auto_collapse = true
-array_auto_expand = true
 reorder_keys = true
 
 # Do not sort key names within [package] section.

--- a/tools/ci/licenserc.yml
+++ b/tools/ci/licenserc.yml
@@ -26,3 +26,4 @@ header:
     - 'rust-toolchain.toml'
     - 'rustfmt.toml'
     - '.cargo/audit.toml'
+    - 'taplo.toml'


### PR DESCRIPTION
As discussed in https://github.com/engula/engula/issues/181, Cargo.toml style guide is not respected. `rustfmt` will support it in the future. 

As a temporary solution, we turn on some `taplo` options, including: 
- sort keys within each section (I think this is the most likely scenario)
- array auto collapse & expand.