### PR TITLE
kernel: execute some update operations

### DIFF
--- a/src/kernel/src/lib.rs
+++ b/src/kernel/src/lib.rs
@@ -56,9 +56,15 @@ mod tests {
         K: Kernel,
         K::UpdateReader: Send + 'static,
     {
+        let stream_name = "stream";
+        let bucket_name = "bucket";
+        let object_name = "object";
+
         let update = KernelUpdateBuilder::default()
             .put_meta("a", "b")
             .remove_meta("b")
+            .add_stream(stream_name)
+            .add_bucket(bucket_name)
             .build();
 
         let handle = {
@@ -73,6 +79,13 @@ mod tests {
         let mut writer = kernel.new_update_writer().await?;
         writer.append(update).await?;
         handle.await.unwrap();
+
+        // Checks if the stream and bucket have been created.
+        kernel.new_stream_writer(stream_name).await.unwrap();
+        kernel
+            .new_sequential_writer(bucket_name, object_name)
+            .await
+            .unwrap();
         Ok(())
     }
 }

--- a/src/kernel/src/local/update_writer.rs
+++ b/src/kernel/src/local/update_writer.rs
@@ -17,24 +17,58 @@ use std::sync::{
     Arc,
 };
 
+use engula_journal::Journal;
+use engula_storage::Storage;
 use tokio::sync::broadcast::Sender;
 
 use crate::{async_trait, Error, KernelUpdate, Result, Sequence, UpdateEvent};
 
-pub struct UpdateWriter {
+pub struct UpdateWriter<J, S> {
+    journal: Arc<J>,
+    storage: Arc<S>,
     sequence: Arc<AtomicU64>,
     tx: Sender<UpdateEvent>,
 }
 
-impl UpdateWriter {
-    pub fn new(sequence: Arc<AtomicU64>, tx: Sender<UpdateEvent>) -> Self {
-        Self { sequence, tx }
+impl<J, S> UpdateWriter<J, S>
+where
+    J: Journal,
+    S: Storage,
+{
+    pub fn new(
+        journal: Arc<J>,
+        storage: Arc<S>,
+        sequence: Arc<AtomicU64>,
+        tx: Sender<UpdateEvent>,
+    ) -> Self {
+        Self {
+            journal,
+            storage,
+            sequence,
+            tx,
+        }
     }
 }
 
 #[async_trait]
-impl crate::UpdateWriter for UpdateWriter {
+impl<J, S> crate::UpdateWriter for UpdateWriter<J, S>
+where
+    J: Journal + Send + Sync,
+    S: Storage + Send + Sync,
+{
     async fn append(&mut self, update: KernelUpdate) -> Result<Sequence> {
+        for stream in &update.add_streams {
+            self.journal.create_stream(stream).await?;
+        }
+        for stream in &update.remove_streams {
+            self.journal.delete_stream(stream).await?;
+        }
+        for bucket in &update.add_buckets {
+            self.storage.create_bucket(bucket).await?;
+        }
+        for bucket in &update.remove_buckets {
+            self.storage.delete_bucket(bucket).await?;
+        }
         let sequence = self.sequence.fetch_add(1, Ordering::SeqCst) + 1;
         self.tx.send((sequence, update)).map_err(Error::unknown)?;
         Ok(sequence)


### PR DESCRIPTION
`Kernel` should create/delete the corresponding streams/buckets on receiving updates. The atomicity is not guaranteed so far.