### PR TITLE
luna: add scanners and version structures

### DIFF
--- a/src/engine/luna/src/lib.rs
+++ b/src/engine/luna/src/lib.rs
@@ -15,7 +15,11 @@
 mod collection;
 mod database;
 mod error;
+mod mem_table;
+mod merging_scanner;
+mod scan;
 mod table;
+mod version;
 
 pub use self::{
     collection::Collection,

--- a/src/engine/luna/src/mem_table.rs
+++ b/src/engine/luna/src/mem_table.rs
@@ -1,0 +1,23 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::scan::Scan;
+
+pub trait MemTable {
+    type Scanner: Scan;
+
+    fn scan(&self) -> Self::Scanner;
+
+    fn approximate_size(&self) -> usize;
+}

--- a/src/engine/luna/src/merging_scanner.rs
+++ b/src/engine/luna/src/merging_scanner.rs
@@ -1,0 +1,54 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::scan::Scan;
+
+pub struct MergingScanner<S> {
+    _children: Vec<S>,
+}
+
+impl<S> MergingScanner<S> {
+    pub fn new(_children: Vec<S>) -> Self {
+        Self { _children }
+    }
+}
+
+impl<S> Scan for MergingScanner<S>
+where
+    S: Scan,
+{
+    fn seek_to_first(&mut self) {
+        unimplemented!();
+    }
+
+    fn seek(&mut self) {
+        unimplemented!();
+    }
+
+    fn next(&mut self) {
+        unimplemented!();
+    }
+
+    fn valid(&self) -> bool {
+        unimplemented!();
+    }
+
+    fn key(&self) -> &[u8] {
+        unimplemented!();
+    }
+
+    fn value(&self) -> &[u8] {
+        unimplemented!();
+    }
+}

--- a/src/engine/luna/src/scan.rs
+++ b/src/engine/luna/src/scan.rs
@@ -1,0 +1,27 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub trait Scan {
+    fn seek_to_first(&mut self);
+
+    fn seek(&mut self);
+
+    fn next(&mut self);
+
+    fn valid(&self) -> bool;
+
+    fn key(&self) -> &[u8];
+
+    fn value(&self) -> &[u8];
+}

--- a/src/engine/luna/src/table/mod.rs
+++ b/src/engine/luna/src/table/mod.rs
@@ -20,7 +20,11 @@ mod table_builder;
 mod table_iter;
 mod table_reader;
 
-pub use self::table_builder::{TableBuilder, TableBuilderOptions};
+pub use self::{
+    table_builder::{TableBuilder, TableBuilderOptions},
+    table_iter::TableIter,
+    table_reader::TableReader,
+};
 
 #[cfg(test)]
 mod tests {

--- a/src/engine/luna/src/table/table_iter.rs
+++ b/src/engine/luna/src/table/table_iter.rs
@@ -30,7 +30,7 @@ async fn read_block_iter<R: RandomRead + Unpin>(reader: &R, mut value: &[u8]) ->
     Ok(block.iter())
 }
 
-pub(crate) struct TableIter<'a, R> {
+pub struct TableIter<'a, R> {
     reader: &'a R,
     index_iter: BlockIter,
     block_iter: Option<BlockIter>,

--- a/src/engine/luna/src/table/table_reader.rs
+++ b/src/engine/luna/src/table/table_reader.rs
@@ -23,7 +23,7 @@ use crate::{
     Result,
 };
 
-pub(crate) struct TableReader<R> {
+pub struct TableReader<R> {
     // For simplicity, the R is used here instead of its reference.
     reader: R,
     index_block: BlockReader,

--- a/src/engine/luna/src/version.rs
+++ b/src/engine/luna/src/version.rs
@@ -1,0 +1,121 @@
+// Copyright 2021 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use engula_futures::io::RandomRead;
+
+use crate::{
+    mem_table::MemTable,
+    merging_scanner::MergingScanner,
+    table::{TableIter, TableReader},
+};
+
+#[allow(dead_code)]
+pub struct Version<M, R> {
+    mem: MemVersion<M>,
+    base: BaseVersion<R>,
+}
+
+#[allow(dead_code)]
+impl<M, R> Version<M, R>
+where
+    M: MemTable,
+    R: RandomRead + Unpin,
+{
+    pub fn scan(&self) -> Scanner<'_, M::Scanner, R> {
+        let mem = self.mem.scan();
+        let base = self.base.scan();
+        Scanner::new(mem, base)
+    }
+}
+
+/// Scans all entries in a [`Version`].
+pub struct Scanner<'a, S, R> {
+    _mem: MemScanner<S>,
+    _base: BaseScanner<'a, R>,
+}
+
+impl<'a, S, R> Scanner<'a, S, R> {
+    pub fn new(_mem: MemScanner<S>, _base: BaseScanner<'a, R>) -> Self {
+        Self { _mem, _base }
+    }
+}
+
+pub struct MemVersion<M> {
+    tables: Vec<Arc<M>>,
+}
+
+/// Scans all tables in a [`MemVersion`].
+type MemScanner<S> = MergingScanner<S>;
+
+impl<M> MemVersion<M>
+where
+    M: MemTable,
+{
+    pub fn scan(&self) -> MergingScanner<M::Scanner> {
+        let children = self.tables.iter().map(|x| x.scan()).collect();
+        MergingScanner::new(children)
+    }
+}
+
+pub struct BaseVersion<R> {
+    levels: Vec<LevelState<R>>,
+}
+
+impl<R> BaseVersion<R>
+where
+    R: RandomRead + Unpin,
+{
+    pub fn scan(&self) -> BaseScanner<'_, R> {
+        let children = self.levels.iter().map(|x| x.scan()).collect();
+        BaseScanner::new(children)
+    }
+}
+
+/// Scans all levels in a [`BaseVersion`].
+pub struct BaseScanner<'a, R> {
+    _children: Vec<LevelScanner<'a, R>>,
+}
+
+impl<'a, R> BaseScanner<'a, R> {
+    pub fn new(_children: Vec<LevelScanner<'a, R>>) -> Self {
+        Self { _children }
+    }
+}
+
+pub struct LevelState<R> {
+    tables: Vec<TableReader<R>>,
+}
+
+impl<R> LevelState<R>
+where
+    R: RandomRead + Unpin,
+{
+    pub fn scan(&self) -> LevelScanner<'_, R> {
+        let children = self.tables.iter().map(|x| x.iter()).collect();
+        LevelScanner::new(children)
+    }
+}
+
+/// Scans all tables in a level.
+pub struct LevelScanner<'a, R> {
+    _children: Vec<TableIter<'a, R>>,
+}
+
+impl<'a, R> LevelScanner<'a, R> {
+    pub fn new(_children: Vec<TableIter<'a, R>>) -> Self {
+        Self { _children }
+    }
+}


### PR DESCRIPTION
This PR sets up a skeleton of scanners without implementation for future development.

Note that I propose to use the `Scanner` concept instead of `Iterator` to avoid confusion with `std::iter::Iterator`. We have two kinds of scanners here, synchronous scanners for memory structures (`MemScanner`) and asynchronous scanners for persistent structures (e.g., `BaseScanner`). Synchronous scanners can share the same `Scan` trait without the problems we discussed in #224, which allows different `MemTable` implementation in the future too.