### PR TITLE
ci: fix boolean logic

### DIFF
--- a/.github/actions/skip/action.yml
+++ b/.github/actions/skip/action.yml
@@ -28,8 +28,7 @@ inputs:
       Output skip=true when and only when none of the changed files located in one of the path,
       the paths is shell-style pattern.
     required: false
-    default: >-
-      "*"
+    default: ''
 outputs:
   skip:
     description: "whether we should skip CI jobs"


### PR DESCRIPTION
This script is needed because GitHub Actions does't support path filter for jobs and steps.

The boolean logic should be, skip CI if and only if all paths-ignore matches and none paths matches.

Previously, the default value of paths is "*", which means all paths are matched. It makes paths-ignore ("*.md", "*.svg") takes no effect.

cc @huachaohuang sorry for introducing this boolean logic bug :-(

Signed-off-by: tison <wander4096@gmail.com>

Bug was found by [rfc: add signle write journal CI #14](https://github.com/engula/engula/runs/4762098913?check_suite_focus=true) where only "*.md" modified but "test" job runs.

Fixes verified by:

* [edit toml](https://github.com/tisonkun/engula/actions/runs/1678010370)
* [edit md](https://github.com/tisonkun/engula/actions/runs/1678009419)