### PR TITLE
journal: refactor event stream

### DIFF
--- a/src/journal/src/local/mem/journal.rs
+++ b/src/journal/src/local/mem/journal.rs
@@ -190,7 +190,7 @@ impl crate::StreamWriter for StreamWriter {
         stream.events.push_back(event);
         stream.end += 1;
         stream.waiter.notify_waiters();
-        Ok(stream.end)
+        Ok(stream.end - 1)
     }
 
     async fn truncate(&mut self, sequence: Sequence) -> Result<()> {

--- a/src/journal/src/local/mem/mod.rs
+++ b/src/journal/src/local/mem/mod.rs
@@ -36,14 +36,17 @@ mod tests {
         let event1 = vec![1];
         let event2 = vec![2];
         let mut writer = j.new_stream_writer(stream_name).await?;
-        assert_eq!(writer.append(event1.clone()).await?, 1);
-        assert_eq!(writer.append(event2.clone()).await?, 2);
+
+        let expected_event1_seq = 0;
+        let expected_event2_seq = 1;
+        assert_eq!(writer.append(event1.clone()).await?, expected_event1_seq);
+        assert_eq!(writer.append(event2.clone()).await?, expected_event2_seq);
 
         let mut reader = j.new_stream_reader(stream_name).await?;
-        reader.seek(0).await?;
+        reader.seek(expected_event1_seq).await?;
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event1));
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event2));
-        reader.seek(1).await?;
+        reader.seek(expected_event2_seq).await?;
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event2));
         Ok(())
     }
@@ -55,11 +58,15 @@ mod tests {
         let j = super::Journal::default();
         j.create_stream(stream_name).await?;
 
+        let expected_event1_seq = 0;
+        let expected_event2_seq = 1;
+        let expected_event3_seq = 2;
+
         // 1. wait not available event
         let mut reader = j.new_stream_reader(stream_name).await?;
         let handle: JoinHandle<Result<()>> = tokio::spawn(async move {
             let event2 = vec![2];
-            reader.seek(1).await?;
+            reader.seek(expected_event2_seq).await?;
             assert_eq!(&reader.wait_next().await?, &event2);
             Ok(())
         });
@@ -70,18 +77,18 @@ mod tests {
         let event2 = vec![2];
         let event3 = vec![3];
         let mut writer = j.new_stream_writer(stream_name).await?;
-        assert_eq!(writer.append(event1.clone()).await?, 1);
-        assert_eq!(writer.append(event2.clone()).await?, 2);
+        assert_eq!(writer.append(event1.clone()).await?, expected_event1_seq);
+        assert_eq!(writer.append(event2.clone()).await?, expected_event2_seq);
 
         handle.await.unwrap()?;
 
         // 2. wait available event
         let mut reader = j.new_stream_reader(stream_name).await?;
-        reader.seek(0).await?;
+        reader.seek(expected_event1_seq).await?;
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event1));
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event2));
 
-        assert_eq!(writer.append(event3.clone()).await?, 3);
+        assert_eq!(writer.append(event3.clone()).await?, expected_event3_seq);
         assert_eq!(&reader.wait_next().await?, &event3);
 
         Ok(())
@@ -96,26 +103,29 @@ mod tests {
 
         let mut reader = j.new_stream_reader(stream_name).await?;
 
+        let expected_event1_seq = 0;
+        let expected_event2_seq = 1;
+
         // seek future sequence
-        reader.seek(1).await?;
+        reader.seek(expected_event2_seq).await?;
 
         let event1 = vec![1];
         let event2 = vec![2];
         let mut writer = j.new_stream_writer(stream_name).await?;
-        assert_eq!(writer.append(event1.clone()).await?, 1);
-        assert_eq!(writer.append(event2.clone()).await?, 2);
+        assert_eq!(writer.append(event1.clone()).await?, expected_event1_seq);
+        assert_eq!(writer.append(event2.clone()).await?, expected_event2_seq);
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event2));
 
         // normal
-        reader.seek(0).await?;
+        reader.seek(expected_event1_seq).await?;
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event1));
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event2));
-        reader.seek(1).await?;
+        reader.seek(expected_event2_seq).await?;
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event2));
 
         // cannot seek truncated sequence
-        writer.truncate(2).await?;
-        let got = reader.seek(1).await;
+        writer.truncate(expected_event2_seq + 1).await?;
+        let got = reader.seek(expected_event2_seq).await;
         assert!(got.is_err());
 
         Ok(())
@@ -131,44 +141,49 @@ mod tests {
         let event1 = vec![1];
         let event2 = vec![2];
         let event3 = vec![3];
+
+        let expected_event1_seq = 0;
+        let expected_event2_seq = 1;
+        let expected_event3_seq = 2;
+
         let mut writer = j.new_stream_writer(stream_name).await?;
-        assert_eq!(writer.append(event1.clone()).await?, 1);
-        assert_eq!(writer.append(event2.clone()).await?, 2);
-        assert_eq!(writer.append(event3.clone()).await?, 3);
+        assert_eq!(writer.append(event1.clone()).await?, expected_event1_seq);
+        assert_eq!(writer.append(event2.clone()).await?, expected_event2_seq);
+        assert_eq!(writer.append(event3.clone()).await?, expected_event3_seq);
 
         // normal
         let mut reader = j.new_stream_reader(stream_name).await?;
-        reader.seek(0).await?;
+        reader.seek(expected_event1_seq).await?;
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event1));
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event2));
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event3));
-        reader.seek(1).await?;
+        reader.seek(expected_event2_seq).await?;
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event2));
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event3));
 
         // truncate
-        writer.truncate(1).await?;
-        reader.seek(1).await?;
+        writer.truncate(expected_event2_seq).await?;
+        reader.seek(expected_event2_seq).await?;
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event2));
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event3));
-        reader.seek(2).await?;
+        reader.seek(expected_event3_seq).await?;
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event3));
 
         // truncate more
-        writer.truncate(2).await?;
-        reader.seek(2).await?;
+        writer.truncate(expected_event3_seq).await?;
+        reader.seek(expected_event3_seq).await?;
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event3));
 
         // truncate truncated sequence is valid as noop
-        writer.truncate(1).await?;
-        reader.seek(2).await?;
+        writer.truncate(expected_event3_seq - 1).await?;
+        reader.seek(expected_event3_seq).await?;
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event3));
-        writer.truncate(2).await?;
-        reader.seek(2).await?;
+        writer.truncate(expected_event3_seq).await?;
+        reader.seek(expected_event3_seq).await?;
         assert_eq!(reader.try_next().await?.as_ref(), Some(&event3));
 
         // cannot truncate future sequence
-        let got = writer.truncate(4).await;
+        let got = writer.truncate(expected_event3_seq + 2).await;
         assert!(got.is_err());
 
         Ok(())

--- a/src/journal/src/stream.rs
+++ b/src/journal/src/stream.rs
@@ -31,7 +31,7 @@ pub trait StreamReader {
 
 #[async_trait]
 pub trait StreamWriter {
-    /// Appends an event.
+    /// Appends an event, returns the sequence of the event just append.
     async fn append(&mut self, event: Vec<u8>) -> Result<Sequence>;
 
     /// Truncates events up to a sequence (exclusive).

--- a/src/kernel/src/kernel.rs
+++ b/src/kernel/src/kernel.rs
@@ -63,7 +63,7 @@ pub trait UpdateReader {
 
 #[async_trait]
 pub trait UpdateWriter {
-    /// Appends an update.
+    /// Appends an update, returns the sequence of the update just append.
     async fn append(&mut self, update: KernelUpdate) -> Result<Sequence>;
 
     /// Releases updates up to a sequence (exclusive).

--- a/src/kernel/src/lib.rs
+++ b/src/kernel/src/lib.rs
@@ -72,7 +72,7 @@ mod tests {
             let mut reader = kernel.new_update_reader().await?;
             tokio::spawn(async move {
                 let update = reader.wait_next().await.unwrap();
-                assert_eq!(update, (1, expect));
+                assert_eq!(update, (0, expect));
             })
         };
 

--- a/src/kernel/src/local/update_writer.rs
+++ b/src/kernel/src/local/update_writer.rs
@@ -69,7 +69,7 @@ where
         for bucket in &update.remove_buckets {
             self.storage.delete_bucket(bucket).await?;
         }
-        let sequence = self.sequence.fetch_add(1, Ordering::SeqCst) + 1;
+        let sequence = self.sequence.fetch_add(1, Ordering::SeqCst);
         self.tx.send((sequence, update)).map_err(Error::unknown)?;
         Ok(sequence)
     }


### PR DESCRIPTION
* `seek` and `truncate` should handle invalid argument:
  * otherwise, `seek` to a truncated sequence and read will return from the current very beginning event, it's not the one on the seek sequence.
  * otherwise, `truncate` a future sequence is noop but you can still append to arrive that sequence so that `truncate`'s semantic doesn't hold.
* `seek` becomes zero-based (seek_to_inclusive) so that we don't have to `+ 1` everywhere.
* `wait_next` is reimplemented, I hope the code more sane.

Signed-off-by: tison <wander4096@gmail.com>

cc @huachaohuang @w41ter-l 