### PR TITLE
docs: update the rfc template

### DIFF
--- a/docs/rfcs/00000000-template.md
+++ b/docs/rfcs/00000000-template.md
@@ -1,9 +1,40 @@
----
-status: '[accepted|released|discarded]'
-discussion: https://github.com/engula/engula/discussions/0
-issue: https://github.com/engula/engula/issues/0
----
+# Feature Name
 
-<!--
-We don't have a template of the content yet. Generally, you should think of the motivation, the technical design, the test design, and alternatives of the proposal.
--->
+- Status: '[accepted|completed|obsoleted]'
+- Discussion: https://github.com/engula/engula/discussions/0
+- Pull Request: https://github.com/engula/engula/pull/0
+- Tracking Issue: https://github.com/engula/engula/issues/0
+
+## Summary
+
+One paragraph explanation of the feature.
+
+## Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+## Detailed design
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+## Drawbacks
+
+Why should we *not* do this?
+
+## Alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+## Unresolved questions
+
+- What parts of the design do you expect to resolve through the RFC process before this gets merged?
+- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
+- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?


### PR DESCRIPTION
The template is mostly derived from [Rust](https://github.com/rust-lang/rfcs/blob/master/0000-template.md).