### PR TITLE
journal: add basic defination of shared journal server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tonic",
  "tonic-build",
 ]
 

--- a/src/journal/Cargo.toml
+++ b/src/journal/Cargo.toml
@@ -15,6 +15,7 @@ futures = "0.3"
 prost = "0.9"
 thiserror = "1.0"
 tokio = { version = "1.13", features = ["full"] }
+tonic = "0.6"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/journal/build.rs
+++ b/src/journal/build.rs
@@ -14,5 +14,6 @@
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::compile_protos("src/remote/grpc/journal.proto")?;
+    tonic_build::compile_protos("src/remote/shared/proto/server.proto")?;
     Ok(())
 }

--- a/src/journal/src/remote/shared/mod.rs
+++ b/src/journal/src/remote/shared/mod.rs
@@ -17,8 +17,9 @@ use super::leader_based::{EpochState, Journal as LeaderBasedJournal, Role};
 mod journal;
 mod master;
 mod orchestrator;
-
+pub mod proto;
 mod segment;
+mod server;
 mod stream_reader;
 mod stream_writer;
 
@@ -32,7 +33,10 @@ pub use stream_writer::Writer as StreamWriter;
 enum Entry {
     /// A placeholder, used in recovery phase.
     Hole,
-    Event(Box<[u8]>),
+    Event {
+        epoch: u32,
+        event: Box<[u8]>,
+    },
 }
 
 /// `SegmentMeta` records the metadata for locating a segment and its data.

--- a/src/journal/src/remote/shared/proto/mod.rs
+++ b/src/journal/src/remote/shared/proto/mod.rs
@@ -1,0 +1,48 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::Entry;
+
+pub mod server {
+    tonic::include_proto!("engula.journal.v1.shared.server");
+}
+
+impl From<Entry> for server::Entry {
+    fn from(e: Entry) -> Self {
+        match e {
+            Entry::Hole => server::Entry {
+                entry_type: server::EntryType::Hole as i32,
+                epoch: 0,
+                event: vec![],
+            },
+            Entry::Event { epoch, event } => server::Entry {
+                entry_type: server::EntryType::Hole as i32,
+                epoch,
+                event: event.into(),
+            },
+        }
+    }
+}
+
+impl From<server::Entry> for Entry {
+    fn from(e: server::Entry) -> Self {
+        match server::EntryType::from_i32(e.entry_type) {
+            Some(server::EntryType::Event) => Entry::Event {
+                event: e.event.into(),
+                epoch: e.epoch,
+            },
+            _ => Entry::Hole,
+        }
+    }
+}

--- a/src/journal/src/remote/shared/proto/server.proto
+++ b/src/journal/src/remote/shared/proto/server.proto
@@ -1,0 +1,60 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package engula.journal.v1.shared.server;
+
+service SharedJournal {
+    // Store some continuous entries to a segment.
+    rpc Store(StoreRequest) returns (StoreResponse);
+
+    // Read some entries from a segment.
+    rpc Read(ReadRequest) returns (stream Entry);
+}
+
+message StoreRequest {
+    uint64 stream_id = 1;
+    uint32 seg_epoch = 2;
+
+    // The epoch of writer.
+    uint32 epoch = 3;
+    // The sequence already acked.
+    uint64 acked_seq = 4;
+
+    uint32 first_index = 5;
+
+    repeated bytes events = 6;
+}
+
+message StoreResponse {}
+
+message ReadRequest {
+    uint64 stream_id = 1;
+    uint32 seg_epoch = 2;
+
+    uint32 start_index = 3;
+    uint32 length = 4;
+}
+
+enum EntryType {
+    HOLE = 0;
+    EVENT = 1;
+}
+
+message Entry {
+    EntryType entry_type = 1;
+    uint32 epoch = 2;
+    bytes event = 3;
+}

--- a/src/journal/src/remote/shared/server/mod.rs
+++ b/src/journal/src/remote/shared/server/mod.rs
@@ -1,0 +1,56 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use async_trait::async_trait;
+use futures::Stream;
+use tonic::{Request, Response, Status};
+
+use super::proto::server as serverpb;
+
+struct ReadStream {}
+
+impl Stream for ReadStream {
+    type Item = Result<serverpb::Entry, Status>;
+
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        todo!()
+    }
+}
+
+struct Server {}
+
+#[async_trait]
+#[allow(unused)]
+impl serverpb::shared_journal_server::SharedJournal for Server {
+    type ReadStream = ReadStream;
+
+    async fn store(
+        &self,
+        input: Request<serverpb::StoreRequest>,
+    ) -> Result<Response<serverpb::StoreResponse>, Status> {
+        todo!()
+    }
+
+    async fn read(
+        &self,
+        input: Request<serverpb::ReadRequest>,
+    ) -> Result<Response<Self::ReadStream>, Status> {
+        todo!()
+    }
+}


### PR DESCRIPTION
This PR closes #325.

Only the basic interface, methods and fields are defined, and the rest will be defined when needed.