### PR TITLE
object-engine: add basic client interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,6 +482,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "object-engine-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "object-engine-proto",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "object-engine-proto"
+version = "0.1.0"
+dependencies = [
+ "prost",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,6 @@ members = [
   "src/server",
   "src/stream-engine/proto",
   "src/stream-engine/client",
+  "src/object-engine/proto",
+  "src/object-engine/client",
 ]

--- a/src/object-engine/client/Cargo.toml
+++ b/src/object-engine/client/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "object-engine-client"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+object-engine-proto = { version = "0.1", path = "../proto" }
+
+prost = "0.9"
+thiserror = "1.0"
+tokio = { version = "1.15", features = ["full"] }
+tonic = "0.6"
+
+[dev-dependencies]
+anyhow = "1.0"

--- a/src/object-engine/client/src/engine.rs
+++ b/src/object-engine/client/src/engine.rs
@@ -1,0 +1,82 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use object_engine_proto::*;
+use tonic::transport::Endpoint;
+
+use crate::{master::Master, Error, Result, Tenant};
+
+#[derive(Clone)]
+pub struct Engine {
+    inner: Arc<EngineInner>,
+}
+
+impl Engine {
+    pub async fn connect(url: impl Into<String>) -> Result<Self> {
+        let chan = Endpoint::new(url.into())
+            .map_err(Error::unknown)?
+            .connect()
+            .await
+            .map_err(Error::unknown)?;
+        let inner = EngineInner {
+            master: Master::new(chan),
+        };
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
+    }
+
+    pub fn tenant(&self, name: &str) -> Tenant {
+        self.inner.new_tenant(name.to_owned())
+    }
+
+    pub async fn create_tenant(&self, name: &str) -> Result<Tenant> {
+        let desc = TenantDesc {
+            name: name.to_owned(),
+            ..Default::default()
+        };
+        let req = CreateTenantRequest { desc: Some(desc) };
+        let req = tenant_request_union::Request::CreateTenant(req);
+        self.inner.tenant_union_call(req).await?;
+        Ok(self.tenant(name))
+    }
+
+    pub async fn delete_tenant(&self, name: &str) -> Result<()> {
+        let req = DeleteTenantRequest {
+            name: name.to_owned(),
+        };
+        let req = tenant_request_union::Request::DeleteTenant(req);
+        self.inner.tenant_union_call(req).await?;
+        Ok(())
+    }
+}
+
+struct EngineInner {
+    master: Master,
+}
+
+impl EngineInner {
+    fn new_tenant(&self, name: String) -> Tenant {
+        Tenant::new(name, self.master.clone())
+    }
+
+    async fn tenant_union_call(
+        &self,
+        req: tenant_request_union::Request,
+    ) -> Result<tenant_response_union::Response> {
+        self.master.tenant_union(req).await
+    }
+}

--- a/src/object-engine/client/src/error.rs
+++ b/src/object-engine/client/src/error.rs
@@ -1,0 +1,49 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use thiserror::Error;
+use tonic::{Code, Status};
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("{0} is not found")]
+    NotFound(String),
+    #[error("{0} already exists")]
+    AlreadyExists(String),
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
+    #[error("invalid response")]
+    InvalidResponse,
+    #[error("unknown error: {0}")]
+    Unknown(String),
+}
+
+impl Error {
+    pub fn unknown(s: impl ToString) -> Self {
+        Self::Unknown(s.to_string())
+    }
+}
+
+impl From<Status> for Error {
+    fn from(s: Status) -> Self {
+        match s.code() {
+            Code::NotFound => Error::NotFound(s.message().to_owned()),
+            Code::AlreadyExists => Error::AlreadyExists(s.message().to_owned()),
+            Code::InvalidArgument => Error::InvalidArgument(s.message().to_owned()),
+            _ => Error::Unknown(s.to_string()),
+        }
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/object-engine/client/src/lib.rs
+++ b/src/object-engine/client/src/lib.rs
@@ -1,0 +1,24 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod engine;
+mod error;
+mod master;
+mod tenant;
+
+pub use self::{
+    engine::Engine,
+    error::{Error, Result},
+    tenant::Tenant,
+};

--- a/src/object-engine/client/src/master.rs
+++ b/src/object-engine/client/src/master.rs
@@ -1,0 +1,70 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use object_engine_proto::*;
+use tonic::transport::Channel;
+
+use crate::{Error, Result};
+
+#[derive(Clone)]
+pub struct Master {
+    client: master_client::MasterClient<Channel>,
+}
+
+impl Master {
+    pub fn new(chan: Channel) -> Self {
+        let client = master_client::MasterClient::new(chan);
+        Self { client }
+    }
+
+    pub async fn tenant(&self, req: TenantRequest) -> Result<TenantResponse> {
+        let res = self.client.clone().tenant(req).await?;
+        Ok(res.into_inner())
+    }
+
+    pub async fn tenant_union(
+        &self,
+        req: tenant_request_union::Request,
+    ) -> Result<tenant_response_union::Response> {
+        let req = TenantRequest {
+            requests: vec![TenantRequestUnion { request: Some(req) }],
+        };
+        let mut res = self.tenant(req).await?;
+        res.responses
+            .pop()
+            .and_then(|x| x.response)
+            .ok_or(Error::InvalidResponse)
+    }
+
+    pub async fn bucket(&self, req: BucketRequest) -> Result<BucketResponse> {
+        let res = self.client.clone().bucket(req).await?;
+        Ok(res.into_inner())
+    }
+
+    pub async fn bucket_union(
+        &self,
+        tenant: String,
+        req: bucket_request_union::Request,
+    ) -> Result<bucket_response_union::Response> {
+        let req = BucketRequest {
+            tenant,
+            requests: vec![BucketRequestUnion { request: Some(req) }],
+        };
+        let mut res = self.bucket(req).await?;
+        res.responses
+            .pop()
+            .and_then(|x| x.response)
+            .ok_or(Error::InvalidResponse)
+    }
+}

--- a/src/object-engine/client/src/tenant.rs
+++ b/src/object-engine/client/src/tenant.rs
@@ -1,0 +1,88 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use object_engine_proto::*;
+
+use crate::{master::Master, Error, Result};
+
+#[derive(Clone)]
+pub struct Tenant {
+    inner: Arc<TenantInner>,
+}
+
+impl Tenant {
+    pub fn new(name: String, master: Master) -> Self {
+        let inner = TenantInner { name, master };
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    pub async fn desc(&self) -> Result<TenantDesc> {
+        let req = DescribeTenantRequest {
+            name: self.inner.name.clone(),
+        };
+        let req = tenant_request_union::Request::DescribeTenant(req);
+        let res = self.inner.tenant_union_call(req).await?;
+        let desc = if let tenant_response_union::Response::DescribeTenant(res) = res {
+            res.desc
+        } else {
+            None
+        };
+        desc.ok_or(Error::InvalidResponse)
+    }
+
+    pub async fn create_bucket(&self, name: &str) -> Result<()> {
+        let desc = BucketDesc {
+            name: name.to_owned(),
+            ..Default::default()
+        };
+        let req = CreateBucketRequest { desc: Some(desc) };
+        let req = bucket_request_union::Request::CreateBucket(req);
+        self.inner.bucket_union_call(req).await?;
+        Ok(())
+    }
+
+    pub async fn delete_bucket(&self, name: &str) -> Result<()> {
+        let req = DeleteBucketRequest {
+            name: name.to_owned(),
+        };
+        let req = bucket_request_union::Request::DeleteBucket(req);
+        self.inner.bucket_union_call(req).await?;
+        Ok(())
+    }
+}
+
+struct TenantInner {
+    name: String,
+    master: Master,
+}
+
+impl TenantInner {
+    async fn tenant_union_call(
+        &self,
+        req: tenant_request_union::Request,
+    ) -> Result<tenant_response_union::Response> {
+        self.master.tenant_union(req).await
+    }
+
+    async fn bucket_union_call(
+        &self,
+        req: bucket_request_union::Request,
+    ) -> Result<bucket_response_union::Response> {
+        self.master.bucket_union(self.name.clone(), req).await
+    }
+}

--- a/src/object-engine/proto/Cargo.toml
+++ b/src/object-engine/proto/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "object-engine-proto"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+prost = "0.9"
+tonic = "0.6"
+
+[build-dependencies]
+tonic-build = "0.6"

--- a/src/object-engine/proto/build.rs
+++ b/src/object-engine/proto/build.rs
@@ -1,0 +1,18 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure().compile(&["proto/master.proto"], &["proto"])?;
+    Ok(())
+}

--- a/src/object-engine/proto/proto/master.proto
+++ b/src/object-engine/proto/proto/master.proto
@@ -1,0 +1,125 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package objectengine.master.v1;
+
+service Master {
+  rpc Tenant(TenantRequest) returns (TenantResponse) {}
+
+  rpc Bucket(BucketRequest) returns (BucketResponse) {}
+}
+
+message TenantRequest { repeated TenantRequestUnion requests = 1; }
+
+message TenantResponse { repeated TenantResponseUnion responses = 1; }
+
+message TenantRequestUnion {
+  oneof request {
+    ListTenantsRequest list_tenants = 1;
+    CreateTenantRequest create_tenant = 2;
+    UpdateTenantRequest update_tenant = 3;
+    DeleteTenantRequest delete_tenant = 4;
+    DescribeTenantRequest describe_tenant = 5;
+  }
+}
+
+message TenantResponseUnion {
+  oneof response {
+    ListTenantsResponse list_tenants = 1;
+    CreateTenantResponse create_tenant = 2;
+    UpdateTenantResponse update_tenant = 3;
+    DeleteTenantResponse delete_tenant = 4;
+    DescribeTenantResponse describe_tenant = 5;
+  }
+}
+
+message ListTenantsRequest {}
+
+message ListTenantsResponse { repeated TenantDesc descs = 1; }
+
+message CreateTenantRequest { TenantDesc desc = 1; }
+
+message CreateTenantResponse {}
+
+message UpdateTenantRequest { TenantDesc desc = 1; }
+
+message UpdateTenantResponse {}
+
+message DeleteTenantRequest { string name = 1; }
+
+message DeleteTenantResponse {}
+
+message DescribeTenantRequest { string name = 1; }
+
+message DescribeTenantResponse { TenantDesc desc = 1; }
+
+message BucketRequest {
+  string tenant = 1;
+  repeated BucketRequestUnion requests = 2;
+}
+
+message BucketResponse { repeated BucketResponseUnion responses = 1; }
+
+message BucketRequestUnion {
+  oneof request {
+    ListBucketsRequest list_buckets = 1;
+    CreateBucketRequest create_bucket = 2;
+    UpdateBucketRequest update_bucket = 3;
+    DeleteBucketRequest delete_bucket = 4;
+    DescribeBucketRequest describe_bucket = 5;
+  }
+}
+
+message BucketResponseUnion {
+  oneof response {
+    ListBucketsResponse list_buckets = 1;
+    CreateBucketResponse create_bucket = 2;
+    UpdateBucketResponse update_bucket = 3;
+    DeleteBucketResponse delete_bucket = 4;
+    DescribeBucketResponse describe_bucket = 5;
+  }
+}
+
+message ListBucketsRequest {}
+
+message ListBucketsResponse { repeated BucketDesc descs = 1; }
+
+message CreateBucketRequest { BucketDesc desc = 1; }
+
+message CreateBucketResponse {}
+
+message UpdateBucketRequest { BucketDesc desc = 1; }
+
+message UpdateBucketResponse {}
+
+message DeleteBucketRequest { string name = 1; }
+
+message DeleteBucketResponse {}
+
+message DescribeBucketRequest { string name = 1; }
+
+message DescribeBucketResponse { BucketDesc desc = 1; }
+
+message TenantDesc {
+  uint64 id = 1;
+  string name = 2;
+}
+
+message BucketDesc {
+  uint64 id = 1;
+  string name = 2;
+  uint64 parent_id = 3;
+}

--- a/src/object-engine/proto/src/lib.rs
+++ b/src/object-engine/proto/src/lib.rs
@@ -1,0 +1,17 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(clippy::all)]
+
+tonic::include_proto!("objectengine.master.v1");


### PR DESCRIPTION
Closes #416 

Basically identical to https://github.com/engula/engula/pull/413.