### PR TITLE
doc: add submodule init steps in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 Clone the repository:
 
 ```sh
-git clone https://github.com/engula/engula.git
+git clone --recursive https://github.com/engula/engula.git
 cd engula
 ```
 


### PR DESCRIPTION
https://stackoverflow.com/a/3796947/12815325.

This steps miss in contributing.md. `cargo build` may fail if not init the submodule.