### PR TITLE
ci: tidy ci settings

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,2 +1,0 @@
-[advisories]
-ignore = ["RUSTSEC-2020-0159"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,16 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        with:
-          repository: editorconfig-checker/editorconfig-checker
-          path: editorconfig-checker
-      - uses: actions/setup-go@v2
-        with:
-          go-version: 1.16
-      - run: |
-          pushd editorconfig-checker && make build && popd && \
-          editorconfig-checker/bin/ec -exclude editorconfig-checker
+      - uses: editorconfig-checker/action-editorconfig-checker@v1
 
   toml:
     if: (github.event_name == 'schedule' && github.repository == 'engula/engula') || (github.event_name != 'schedule')


### PR DESCRIPTION
Remove .cargo/audit.toml as we don't depend on chrono anymore and thus we don't have to ignore it anymore.

Replace manually settings up editorconfig checker with an existing gha.

Signed-off-by: tison <wander4096@gmail.com>