### PR TITLE
object-engine/master: use tenant/bucket names as unique indentifiers

### DIFF
--- a/src/object-engine/client/src/bucket.rs
+++ b/src/object-engine/client/src/bucket.rs
@@ -17,17 +17,17 @@ use object_engine_master::Master;
 #[allow(dead_code)]
 #[derive(Clone)]
 pub struct Bucket {
+    name: String,
+    tenant: String,
     master: Master,
-    tenant_id: u64,
-    bucket_id: u64,
 }
 
 impl Bucket {
-    pub(crate) fn new(master: Master, tenant_id: u64, bucket_id: u64) -> Self {
+    pub(crate) fn new(name: String, tenant: String, master: Master) -> Self {
         Self {
+            name,
+            tenant,
             master,
-            tenant_id,
-            bucket_id,
         }
     }
 }

--- a/src/object-engine/client/src/engine.rs
+++ b/src/object-engine/client/src/engine.rs
@@ -27,14 +27,13 @@ impl Engine {
         Ok(Self { master })
     }
 
-    pub fn tenant(&self, id: u64) -> Tenant {
-        Tenant::new(self.master.clone(), id)
+    pub fn tenant(&self, name: &str) -> Tenant {
+        Tenant::new(name.to_owned(), self.master.clone())
     }
 
     pub async fn create_tenant(&self, name: &str) -> Result<TenantDesc> {
         let desc = TenantDesc {
             name: name.to_owned(),
-            ..Default::default()
         };
         self.master.create_tenant(desc).await
     }

--- a/src/object-engine/client/src/tenant.rs
+++ b/src/object-engine/client/src/tenant.rs
@@ -18,17 +18,17 @@ use crate::{Bucket, Result};
 
 #[derive(Clone)]
 pub struct Tenant {
+    name: String,
     master: Master,
-    tenant_id: u64,
 }
 
 impl Tenant {
-    pub fn new(master: Master, tenant_id: u64) -> Self {
-        Self { master, tenant_id }
+    pub(crate) fn new(name: String, master: Master) -> Self {
+        Self { name, master }
     }
 
-    pub fn bucket(&self, id: u64) -> Bucket {
-        Bucket::new(self.master.clone(), self.tenant_id, id)
+    pub fn bucket(&self, name: &str) -> Bucket {
+        Bucket::new(name.to_owned(), self.name.clone(), self.master.clone())
     }
 
     pub async fn create_bucket(&self, name: &str) -> Result<BucketDesc> {
@@ -36,6 +36,6 @@ impl Tenant {
             name: name.to_owned(),
             ..Default::default()
         };
-        self.master.create_bucket(self.tenant_id, desc).await
+        self.master.create_bucket(self.name.clone(), desc).await
     }
 }

--- a/src/object-engine/master/proto/bucket.proto
+++ b/src/object-engine/master/proto/bucket.proto
@@ -17,7 +17,7 @@ syntax = "proto3";
 package objectengine.master.v1;
 
 message BucketRequest {
-  uint64 tenant_id = 1;
+  string tenant = 1;
   repeated BucketRequestUnion requests = 2;
 }
 
@@ -29,7 +29,7 @@ message BucketRequestUnion {
     CreateBucketRequest create_bucket = 2;
     UpdateBucketRequest update_bucket = 3;
     DeleteBucketRequest delete_bucket = 4;
-    LookupBucketRequest lookup_bucket = 5;
+    DescribeBucketRequest describe_bucket = 5;
   }
 }
 
@@ -39,7 +39,7 @@ message BucketResponseUnion {
     CreateBucketResponse create_bucket = 2;
     UpdateBucketResponse update_bucket = 3;
     DeleteBucketResponse delete_bucket = 4;
-    LookupBucketResponse lookup_bucket = 5;
+    DescribeBucketResponse describe_bucket = 5;
   }
 }
 
@@ -55,16 +55,15 @@ message UpdateBucketRequest { BucketDesc desc = 1; }
 
 message UpdateBucketResponse {}
 
-message DeleteBucketRequest { uint64 id = 1; }
+message DeleteBucketRequest { string name = 1; }
 
 message DeleteBucketResponse {}
 
-message LookupBucketRequest { string name = 1; }
+message DescribeBucketRequest { string name = 1; }
 
-message LookupBucketResponse { BucketDesc desc = 1; }
+message DescribeBucketResponse { BucketDesc desc = 1; }
 
 message BucketDesc {
-  uint64 id = 1;
-  string name = 2;
-  uint64 parent_id = 3;
+  string name = 1;
+  string tenant = 2;
 }

--- a/src/object-engine/master/proto/tenant.proto
+++ b/src/object-engine/master/proto/tenant.proto
@@ -26,7 +26,7 @@ message TenantRequestUnion {
     CreateTenantRequest create_tenant = 2;
     UpdateTenantRequest update_tenant = 3;
     DeleteTenantRequest delete_tenant = 4;
-    LookupTenantRequest lookup_tenant = 5;
+    DescribeTenantRequest describe_tenant = 5;
   }
 }
 
@@ -36,7 +36,7 @@ message TenantResponseUnion {
     CreateTenantResponse create_tenant = 2;
     UpdateTenantResponse update_tenant = 3;
     DeleteTenantResponse delete_tenant = 4;
-    LookupTenantResponse lookup_tenant = 5;
+    DescribeTenantResponse describe_tenant = 5;
   }
 }
 
@@ -52,15 +52,12 @@ message UpdateTenantRequest { TenantDesc desc = 1; }
 
 message UpdateTenantResponse {}
 
-message DeleteTenantRequest { uint64 id = 1; }
+message DeleteTenantRequest { string name = 1; }
 
 message DeleteTenantResponse {}
 
-message LookupTenantRequest { string name = 1; }
+message DescribeTenantRequest { string name = 1; }
 
-message LookupTenantResponse { TenantDesc desc = 1; }
+message DescribeTenantResponse { TenantDesc desc = 1; }
 
-message TenantDesc {
-  uint64 id = 1;
-  string name = 2;
-}
+message TenantDesc { string name = 1; }

--- a/src/object-engine/master/src/master.rs
+++ b/src/object-engine/master/src/master.rs
@@ -39,11 +39,11 @@ impl Master {
         desc.ok_or_else(|| Error::internal("missing tenant descriptor"))
     }
 
-    pub async fn lookup_tenant(&self, name: String) -> Result<TenantDesc> {
-        let req = LookupTenantRequest { name };
-        let req = tenant_request_union::Request::LookupTenant(req);
+    pub async fn describe_tenant(&self, name: String) -> Result<TenantDesc> {
+        let req = DescribeTenantRequest { name };
+        let req = tenant_request_union::Request::DescribeTenant(req);
         let res = self.tenant_union(req).await?;
-        let desc = if let tenant_response_union::Response::LookupTenant(res) = res {
+        let desc = if let tenant_response_union::Response::DescribeTenant(res) = res {
             res.desc
         } else {
             None
@@ -51,10 +51,10 @@ impl Master {
         desc.ok_or_else(|| Error::internal("missing tenant descriptor"))
     }
 
-    pub async fn create_bucket(&self, tenant_id: u64, desc: BucketDesc) -> Result<BucketDesc> {
+    pub async fn create_bucket(&self, tenant: String, desc: BucketDesc) -> Result<BucketDesc> {
         let req = CreateBucketRequest { desc: Some(desc) };
         let req = bucket_request_union::Request::CreateBucket(req);
-        let res = self.bucket_union(tenant_id, req).await?;
+        let res = self.bucket_union(tenant, req).await?;
         let desc = if let bucket_response_union::Response::CreateBucket(res) = res {
             res.desc
         } else {
@@ -63,11 +63,11 @@ impl Master {
         desc.ok_or_else(|| Error::internal("missing bucket descriptor"))
     }
 
-    pub async fn lookup_bucket(&self, tenant_id: u64, name: String) -> Result<BucketDesc> {
-        let req = LookupBucketRequest { name };
-        let req = bucket_request_union::Request::LookupBucket(req);
-        let res = self.bucket_union(tenant_id, req).await?;
-        let desc = if let bucket_response_union::Response::LookupBucket(res) = res {
+    pub async fn describe_bucket(&self, tenant: String, name: String) -> Result<BucketDesc> {
+        let req = DescribeBucketRequest { name };
+        let req = bucket_request_union::Request::DescribeBucket(req);
+        let res = self.bucket_union(tenant, req).await?;
+        let desc = if let bucket_response_union::Response::DescribeBucket(res) = res {
             res.desc
         } else {
             None
@@ -103,11 +103,11 @@ impl Master {
 
     pub async fn bucket_union(
         &self,
-        tenant_id: u64,
+        tenant: String,
         req: bucket_request_union::Request,
     ) -> Result<bucket_response_union::Response> {
         let req = BucketRequest {
-            tenant_id,
+            tenant,
             requests: vec![BucketRequestUnion { request: Some(req) }],
         };
         let mut res = self.bucket(req).await?;


### PR DESCRIPTION
Simplifies RPC interactions between components.