### PR TITLE
Add issue templates 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 name: Bug report
-description: Problems and issues with the software
+description: Problems with the software
 labels: [ "bug" ]
 body:
   - type: markdown
     attributes:
       value: |
-        Thank you very much for submitting feedback to Engula to help Engula develop better.
+        Thank you very much for submitting feedback to Engula.
 
-        If it is an idea or help wanted, please go to [Github Discussion](https://github.com/engula/engula/discussions) forum.
+        If it is an idea or help wanted, please go to [Github Discussion](https://github.com/engula/engula/discussions).
   - type: checkboxes
     attributes:
       label: Search before asking
@@ -44,7 +44,7 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: What did you see instead
+      label: What did you see instead?
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -34,8 +34,7 @@ body:
   - type: textarea
     attributes:
       label: Minimal reproduce step
-      placeholder: >
-        Please try to give reproducing steps to facilitate quick location of the problem.
+      description: Please try to give reproducing steps to facilitate quick location of the problem.
     validations:
       required: true
   - type: textarea
@@ -46,7 +45,6 @@ body:
   - type: textarea
     attributes:
       label: What did you see instead
-      description: Describe the bug.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,62 @@
+# Copyright 2022 The Engula Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Bug report
+description: Problems and issues with the software
+labels: [ "bug" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you very much for submitting feedback to Engula to help Engula develop better.
+
+        If it is an idea or help wanted, please go to [Github Discussion](https://github.com/engula/engula/discussions) forum.
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please make sure to search in the [issues](https://github.com/engula/engula/issues) first to see whether the same issue was reported already.
+      options:
+        - label: >
+            I had searched in the [issues](https://github.com/engula/engula/issues) and found no similar issues.
+          required: true
+  - type: textarea
+    attributes:
+      label: Minimal reproduce step
+      placeholder: >
+        Please try to give reproducing steps to facilitate quick location of the problem.
+  - type: textarea
+    attributes:
+      label: What did you expect to see?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What did you see instead
+      description: Describe the bug.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Anything Else?
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit a PR?
+      description: >
+        We very much look forward to developers or users to help solve Engula problems together. If you are willing to submit a PR to fix this problem, please tick it.
+      options:
+        - label: I'm willing to submit a PR!
+  - type: markdown
+    attributes:
+      value: "Thanks for completing our form!"

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -36,6 +36,8 @@ body:
       label: Minimal reproduce step
       placeholder: >
         Please try to give reproducing steps to facilitate quick location of the problem.
+    validations:
+      required: true
   - type: textarea
     attributes:
       label: What did you expect to see?

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,19 @@
+# Copyright 2022 The Engula Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question or get support
+    url: https://github.com/engula/engula/discussions/categories/q-a
+    about: Ask a question or request support for using Engula

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -38,8 +38,7 @@ body:
   - type: textarea
     attributes:
       label: Solution
-      placeholder: >
-        Describe the proposed solution and add related materials like links if any.
+      description: Describe the proposed solution and add related materials like links if any.
   - type: checkboxes
     attributes:
       label: Are you willing to submit a PR?

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,52 @@
+# Copyright 2022 The Engula Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Enhancement
+description: Enhance code, document, and more
+labels: [ "enhancement" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you very much for your good enhancement for Engula!
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please make sure to search in the [issues](https://github.com/engula/engula/issues) first to see whether the same issue was reported already.
+      options:
+        - label: >
+            I had searched in the [issues](https://github.com/engula/engula/issues) and found no similar issues.
+          required: true
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: Describe the motivation you'd like to make this enhancement.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Solution
+      placeholder: >
+        Describe the proposed solution and add related materials like links if any.
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit a PR?
+      description: >
+        We very much look forward to developers or users to help solve Engula problems together. If you are willing to submit a PR to fix this problem, please tick it.
+      options:
+        - label: I'm willing to submit a PR!
+  - type: markdown
+    attributes:
+      value: "Thanks for completing our form!"

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -19,7 +19,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you very much for your good enhancement for Engula!
+        Thank you very much for your enhancement for Engula!
   - type: checkboxes
     attributes:
       label: Search before asking


### PR DESCRIPTION
This closes #582.

You can see the result at [the fork repo](https://github.com/tisonkun/engula/issues/new/choose).

I think sooner or later we should add an entry for "New Feature", but I don't find a good workflow for them as we don't use it yet actually. So I keep "blank_issues_enabled: true" and postpone how we issue a new feature later.

Signed-off-by: tison <wander4096@gmail.com>

cc @huachaohuang @w41ter-l @PsiACE
cc @jackwener these templates learn a lot from those of Apache Doris (Incubating).