### PR TITLE
object-engine: add local manifest for lsmstore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +262,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -621,8 +642,14 @@ name = "object-engine-lsmstore"
 version = "0.3.0"
 dependencies = [
  "bytes",
+ "crc",
  "object-engine-common",
  "object-engine-filestore",
+ "prost",
+ "tempdir",
+ "tokio",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -827,13 +854,26 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -843,8 +883,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -853,6 +908,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1025,6 +1089,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]
@@ -1219,7 +1293,7 @@ dependencies = [
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util 0.7.0",

--- a/src/object-engine/lsmstore/Cargo.toml
+++ b/src/object-engine/lsmstore/Cargo.toml
@@ -12,3 +12,13 @@ object-engine-common = { version = "0.3", path = "../common" }
 object-engine-filestore = { version = "0.3", path = "../filestore" }
 
 bytes = "1.1"
+prost = "0.9"
+tokio = { version = "1.15", features = ["full"] }
+tonic = "0.6"
+crc = "2.1.0"
+
+[dev-dependencies]
+tempdir = "0.3.7"
+
+[build-dependencies]
+tonic-build = "0.6"

--- a/src/object-engine/lsmstore/Cargo.toml
+++ b/src/object-engine/lsmstore/Cargo.toml
@@ -12,10 +12,10 @@ object-engine-common = { version = "0.3", path = "../common" }
 object-engine-filestore = { version = "0.3", path = "../filestore" }
 
 bytes = "1.1"
+crc = "2.1.0"
 prost = "0.9"
 tokio = { version = "1.15", features = ["full"] }
 tonic = "0.6"
-crc = "2.1.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/src/object-engine/lsmstore/build.rs
+++ b/src/object-engine/lsmstore/build.rs
@@ -12,18 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod bucket_iter;
-mod store;
-mod table;
-mod versions;
-
-use object_engine_common::{Error, Result};
-
-pub use self::{
-    bucket_iter::BucketIter,
-    store::{Bucket, Store, Tenant},
-    table::{
-        Key, TableBuilder, TableBuilderOptions, TableDesc, TableIter, TableReader, Timestamp,
-        ValueType,
-    },
-};
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tonic_build::configure().compile(&["proto/manifest.proto"], &["proto"])?;
+    Ok(())
+}

--- a/src/object-engine/lsmstore/proto/manifest.proto
+++ b/src/object-engine/lsmstore/proto/manifest.proto
@@ -18,59 +18,55 @@ package objectengine.manifest.v1;
 
 message VersionEdit {
 
-	string tenant = 1;
+  string tenant = 1;
 
-	message Bucket {
-		string name = 1;
-	};
+  message Bucket { string name = 1; };
 
-	repeated Bucket add_buckets = 2;
-	repeated string remove_buckets = 3;
+  repeated Bucket add_buckets = 2;
+  repeated string remove_buckets = 3;
 
-	message Range {
-		uint64 id = 1;
-		string bucket = 2;
-		bytes smallest = 3;
-		bytes largest = 4;
-	}
+  message Range {
+    uint64 id = 1;
+    string bucket = 2;
+    bytes smallest = 3;
+    bytes largest = 4;
+  }
 
-	message RangeID {
-		uint64 id = 1;
-		string bucket = 2;
-	}
+  message RangeID {
+    uint64 id = 1;
+    string bucket = 2;
+  }
 
-	repeated Range add_ranges = 4;
-	repeated RangeID remove_ranges = 5;
+  repeated Range add_ranges = 4;
+  repeated RangeID remove_ranges = 5;
 
-	message File {
-		string bucket = 1;
-		uint64 range_id = 2;
-		string name = 3;
-		uint32 level = 4;
-		bytes smallest = 5;
-		bytes largest = 6;
-	};
+  message File {
+    string bucket = 1;
+    uint64 range_id = 2;
+    string name = 3;
+    uint32 level = 4;
+    bytes smallest = 5;
+    bytes largest = 6;
+  };
 
-	message FileID {
-		string name = 1;
-		string bucket = 2;
-		uint64 range_id = 3;
-	}
+  message FileID {
+    string name = 1;
+    string bucket = 2;
+    uint64 range_id = 3;
+  }
 
-	repeated File add_files = 6;
-	repeated FileID remove_files = 7;
+  repeated File add_files = 6;
+  repeated FileID remove_files = 7;
 
-	message MetaEntry {
-		string key = 1;
-		string value = 2;
-	}
+  message MetaEntry {
+    string key = 1;
+    string value = 2;
+  }
 
-	repeated MetaEntry add_metas = 8;
-	repeated string remove_metas = 9;
+  repeated MetaEntry add_metas = 8;
+  repeated string remove_metas = 9;
 
-	uint64 next_file_num = 10;
+  uint64 next_file_num = 10;
 }
 
-message VersionEditList {
-	repeated VersionEdit edits = 1;
-}
+message VersionEditList { repeated VersionEdit edits = 1; }

--- a/src/object-engine/lsmstore/proto/manifest.proto
+++ b/src/object-engine/lsmstore/proto/manifest.proto
@@ -1,0 +1,76 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package objectengine.manifest.v1;
+
+message VersionEdit {
+
+	string tenant = 1;
+
+	message Bucket {
+		string name = 1;
+	};
+
+	repeated Bucket add_buckets = 2;
+	repeated string remove_buckets = 3;
+
+	message Range {
+		uint64 id = 1;
+		string bucket = 2;
+		bytes smallest = 3;
+		bytes largest = 4;
+	}
+
+	message RangeID {
+		uint64 id = 1;
+		string bucket = 2;
+	}
+
+	repeated Range add_ranges = 4;
+	repeated RangeID remove_ranges = 5;
+
+	message File {
+		string bucket = 1;
+		uint64 range_id = 2;
+		string name = 3;
+		uint32 level = 4;
+		bytes smallest = 5;
+		bytes largest = 6;
+	};
+
+	message FileID {
+		string name = 1;
+		string bucket = 2;
+		uint64 range_id = 3;
+	}
+
+	repeated File add_files = 6;
+	repeated FileID remove_files = 7;
+
+	message MetaEntry {
+		string key = 1;
+		string value = 2;
+	}
+
+	repeated MetaEntry add_metas = 8;
+	repeated string remove_metas = 9;
+
+	uint64 next_file_num = 10;
+}
+
+message VersionEditList {
+	repeated VersionEdit edits = 1;
+}

--- a/src/object-engine/lsmstore/src/store.rs
+++ b/src/object-engine/lsmstore/src/store.rs
@@ -12,28 +12,83 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{BucketIter, Result};
+use std::{
+    collections::{hash_map, HashMap},
+    path::PathBuf,
+    sync::Arc,
+};
 
-pub struct Store {}
+use tokio::sync::Mutex;
+
+use crate::{versions::VersionSet, BucketIter, Error, Result};
+
+pub struct Store {
+    inner: Arc<Mutex<Inner>>,
+}
+
+struct Inner {
+    base_dir: PathBuf,
+    version_sets: HashMap<String, VersionSet>, // tenant -> VersionSet
+}
 
 impl Store {
-    pub async fn tenant(&self, _name: &str) -> Result<Tenant> {
-        todo!();
+    pub async fn new(base_dir: impl Into<PathBuf>) -> Result<Self> {
+        let inner = Inner {
+            base_dir: base_dir.into(),
+            version_sets: HashMap::new(),
+        };
+        Ok(Self {
+            inner: Arc::new(Mutex::new(inner)),
+        })
+    }
+
+    pub async fn tenant(&self, name: &str) -> Result<Tenant> {
+        let mut inner = self.inner.lock().await;
+        let base_dir = inner.base_dir.to_owned();
+        match inner.version_sets.entry(name.to_owned()) {
+            hash_map::Entry::Occupied(_) => {}
+            hash_map::Entry::Vacant(ent) => {
+                ent.insert(VersionSet::new(base_dir, name).await?);
+            }
+        }
+        Ok(Tenant {
+            tenant: name.to_owned(),
+            inner: self.inner.clone(),
+        })
     }
 }
 
-pub struct Tenant {}
+pub struct Tenant {
+    tenant: String,
+    inner: Arc<Mutex<Inner>>,
+}
 
 impl Tenant {
-    pub async fn bucket(&self, _name: &str) -> Result<Bucket> {
-        todo!();
+    pub async fn bucket(&self, name: &str) -> Result<Bucket> {
+        Ok(Bucket {
+            tenant: self.tenant.to_owned(),
+            bucket: name.to_owned(),
+            inner: self.inner.clone(),
+        })
     }
 }
 
-pub struct Bucket {}
+pub struct Bucket {
+    tenant: String,
+    bucket: String,
+    inner: Arc<Mutex<Inner>>,
+}
 
 impl Bucket {
     pub async fn get(&self, _id: &[u8]) -> Result<Option<Vec<u8>>> {
+        let inner = self.inner.lock().await;
+        let vs = inner
+            .version_sets
+            .get(&self.tenant)
+            .ok_or_else(|| Error::NotFound(format!("tenant {}", &self.tenant)))?;
+        let current = vs.current_version().await;
+        let _current = current.bucket_version(&self.bucket).await?;
+
         todo!();
     }
 

--- a/src/object-engine/lsmstore/src/store.rs
+++ b/src/object-engine/lsmstore/src/store.rs
@@ -48,7 +48,7 @@ impl Store {
         match inner.version_sets.entry(name.to_owned()) {
             hash_map::Entry::Occupied(_) => {}
             hash_map::Entry::Vacant(ent) => {
-                ent.insert(VersionSet::new(base_dir, name).await?);
+                ent.insert(VersionSet::open(base_dir, name).await?);
             }
         }
         Ok(Tenant {

--- a/src/object-engine/lsmstore/src/versions/manifest.rs
+++ b/src/object-engine/lsmstore/src/versions/manifest.rs
@@ -1,0 +1,304 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{io, sync::Arc};
+
+use crc::{Crc, CRC_32_ISCSI};
+use tokio::{
+    fs,
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::Mutex,
+};
+
+use crate::*;
+
+/// Log File format:
+///
+/// File is broken down into variable sized records. The format of each record
+/// is described below.
+///       +-----+-------------+--+----+----------+------+-- ... ----+
+/// File  | r0  |        r1   |P | r2 |    r3    |  r4  |           |
+///       +-----+-------------+--+----+----------+------+-- ... ----+
+///       <--- BLOCK_SIZE ------>|<-- BLOCK_SIZE ------>|
+///  rn = variable size records
+///  P = Padding
+///
+/// Data is written out in BLOCK_SIZE chunks. If next record does not fit
+/// into the space left, the leftover space will be padded with \0.
+///
+/// Record format(Rocksdb Legacy):
+///
+/// +---------+-----------+-----------+--- ... ---+
+/// |CRC (4B) | Size (2B) | Type (1B) | Payload   |
+/// +---------+-----------+-----------+--- ... ---+
+///
+/// CRC = 32bit hash computed over the record type and payload using CRC
+/// Size = Length of the payload data
+/// Type = Type of record
+///        (CHUNK_TYPE_FULL, CHUNK_TYPE_FIRST, CHUNK_TYPE_LAST,
+/// CHUNK_TYPE_MIDDLE )        The type is used to group a bunch of records
+/// together to represent        blocks that are larger than BLOCK_SIZE
+/// Payload = Byte stream as long as specified by the payload size
+
+const BLOCK_SIZE: usize = 32 * 1024;
+const HEADER_SIZE: usize = 7;
+pub const MAX_FILE_SIZE: usize = 128 << 20;
+
+pub const CRC: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
+
+const CHUNK_TYPE_FULL: u8 = 1;
+const CHUNK_TYPE_FIRST: u8 = 2;
+const CHUNK_TYPE_MIDDLE: u8 = 3;
+const CHUNK_TYPE_LAST: u8 = 4;
+
+pub struct Writer {
+    inner: Arc<Mutex<WriterInner>>,
+}
+
+struct WriterInner {
+    w: fs::File,
+    buf: [u8; BLOCK_SIZE],
+    pending: bool,
+    first: bool,
+    chunk_written: usize,
+    written_block_cnt: u64,
+    chunk_start: usize,
+    chunk_end: usize,
+}
+
+impl Writer {
+    pub fn new(w: fs::File) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(WriterInner {
+                w,
+                buf: [0u8; BLOCK_SIZE],
+                pending: false,
+                first: false,
+                written_block_cnt: 0,
+                chunk_start: 0,
+                chunk_end: 0,
+                chunk_written: 0,
+            })),
+        }
+    }
+
+    pub async fn append(&mut self, record: &[u8]) -> Result<()> {
+        let mut inner = self.inner.lock().await;
+        if inner.pending {
+            inner.fill_header(true);
+        }
+        inner.chunk_start = inner.chunk_end;
+        inner.chunk_end += HEADER_SIZE;
+        if inner.chunk_end > BLOCK_SIZE {
+            for k in inner.chunk_start..BLOCK_SIZE {
+                inner.buf[k] = 0
+            }
+            inner.write_block().await?
+        }
+        inner.first = true;
+        inner.pending = true;
+
+        let mut buf = record;
+        while !buf.is_empty() {
+            if inner.chunk_end == BLOCK_SIZE {
+                inner.fill_header(false);
+                inner.write_block().await?;
+                inner.first = false;
+            }
+            let pos = inner.chunk_end;
+            let (src, remain) = if buf.len() < inner.buf[pos..].len() {
+                inner.chunk_end += buf.len();
+                (buf, &buf[buf.len()..])
+            } else {
+                inner.chunk_end += inner.buf[pos..].len();
+                (
+                    &buf[..inner.buf[pos..].len()],
+                    &buf[inner.buf[pos..].len()..],
+                )
+            };
+            inner.buf[pos..pos + src.len()].copy_from_slice(src);
+            buf = remain;
+        }
+
+        Ok(())
+    }
+
+    pub async fn flush_and_sync(&mut self) -> Result<()> {
+        let mut inner = self.inner.lock().await;
+        inner.write_pending().await?;
+        inner.w.flush().await?;
+        inner.w.sync_all().await?;
+        Ok(())
+    }
+
+    pub async fn accumulated_size(&self) -> usize {
+        let inner = self.inner.lock().await;
+        inner.written_block_cnt as usize * BLOCK_SIZE + inner.chunk_end
+    }
+}
+
+impl WriterInner {
+    fn fill_header(&mut self, last: bool) {
+        assert!(self.chunk_start + HEADER_SIZE <= self.chunk_end && self.chunk_end <= BLOCK_SIZE);
+        let typ = if last {
+            if self.first {
+                CHUNK_TYPE_FULL
+            } else {
+                CHUNK_TYPE_LAST
+            }
+        } else if self.first {
+            CHUNK_TYPE_FIRST
+        } else {
+            CHUNK_TYPE_MIDDLE
+        };
+        self.buf[self.chunk_start + 6] = typ;
+        let crc = CRC.checksum(&self.buf[self.chunk_start + 6..self.chunk_end]);
+        let data_size = (self.chunk_end - self.chunk_start - HEADER_SIZE) as u16;
+        self.buf[self.chunk_start..self.chunk_start + 4].copy_from_slice(&crc.to_le_bytes());
+        self.buf[self.chunk_start + 4..self.chunk_start + 6]
+            .copy_from_slice(&data_size.to_le_bytes());
+    }
+
+    async fn write_block(&mut self) -> Result<()> {
+        if self.pending {
+            self.fill_header(true);
+            self.pending = false;
+        }
+        self.w.write_all(&self.buf[self.chunk_written..]).await?;
+        self.chunk_start = 0;
+        self.chunk_end = HEADER_SIZE;
+        self.chunk_written = 0;
+        self.written_block_cnt += 1;
+        Ok(())
+    }
+
+    async fn write_pending(&mut self) -> Result<()> {
+        if self.pending {
+            self.fill_header(true);
+            self.pending = false;
+        }
+        self.w
+            .write_all(&self.buf[self.chunk_written..self.chunk_end])
+            .await?;
+        self.chunk_written = self.chunk_end;
+        Ok(())
+    }
+}
+
+pub struct Reader {
+    inner: Arc<Mutex<ReaderInner>>,
+}
+
+struct ReaderInner {
+    r: fs::File,
+    buf: [u8; BLOCK_SIZE],
+    chunk_start: usize,
+    chunk_end: usize,
+    read_bytes: usize,
+    last: bool,
+    block_num: i64,
+}
+
+impl Reader {
+    pub fn new(r: fs::File) -> Self {
+        let buf = [0u8; BLOCK_SIZE];
+        let inner = Arc::new(Mutex::new(ReaderInner {
+            r,
+            buf,
+            chunk_start: 0,
+            chunk_end: 0,
+            read_bytes: 0,
+            last: false,
+            block_num: -1,
+        }));
+        Self { inner }
+    }
+
+    pub async fn read(&mut self) -> Result<Vec<u8>> {
+        let mut inner = self.inner.lock().await;
+        inner.chunk_start = inner.chunk_end;
+        inner.next_chunk(true).await?;
+
+        while inner.chunk_start == inner.chunk_end {
+            if inner.last {
+                return Err(Error::Io(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "EOF",
+                )));
+            }
+            inner.next_chunk(false).await?;
+        }
+        let mut res = vec![0u8; inner.chunk_end - inner.chunk_start];
+        res.copy_from_slice(&inner.buf[inner.chunk_start..inner.chunk_end]);
+        inner.chunk_start = inner.chunk_end;
+
+        Ok(res)
+    }
+}
+
+impl ReaderInner {
+    async fn next_chunk(&mut self, first_read: bool) -> Result<()> {
+        loop {
+            if self.chunk_end + HEADER_SIZE <= self.read_bytes {
+                let checksum = u32::from_le_bytes(
+                    self.buf[self.chunk_end..self.chunk_end + 4]
+                        .try_into()
+                        .unwrap(),
+                );
+                let data_size = u16::from_le_bytes(
+                    self.buf[self.chunk_end + 4..self.chunk_end + 6]
+                        .try_into()
+                        .unwrap(),
+                ) as usize;
+                let typ = self.buf[self.chunk_end + 6];
+
+                if checksum == 0 && data_size == 0 && typ == 0 {
+                    return Err(Error::Corrupted("zeroed chunk".to_string()));
+                }
+
+                self.chunk_start = self.chunk_end + HEADER_SIZE;
+                self.chunk_end = self.chunk_start + data_size;
+                if self.chunk_end > self.read_bytes {
+                    return Err(Error::Corrupted("invalid chunk".to_string()));
+                }
+                if checksum
+                    != CRC.checksum(&self.buf[self.chunk_start - HEADER_SIZE + 6..self.chunk_end])
+                {
+                    return Err(Error::Corrupted("invalid chunk".to_string()));
+                }
+                if first_read && typ != CHUNK_TYPE_FULL && typ != CHUNK_TYPE_FIRST {
+                    continue;
+                }
+                self.last = typ == CHUNK_TYPE_LAST || typ == CHUNK_TYPE_FULL;
+                return Ok(());
+            }
+
+            if self.read_bytes < BLOCK_SIZE && self.block_num >= 0 {
+                if !first_read || self.chunk_start != self.read_bytes {
+                    return Err(Error::Corrupted("invalid chunk".to_string()));
+                }
+                return Err(Error::Io(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "EOF",
+                )));
+            }
+
+            let readed = self.r.read(&mut self.buf[..]).await?;
+            self.chunk_start = 0;
+            self.chunk_end = 0;
+            self.read_bytes = readed;
+            self.block_num += 1;
+        }
+    }
+}

--- a/src/object-engine/lsmstore/src/versions/manifest.rs
+++ b/src/object-engine/lsmstore/src/versions/manifest.rs
@@ -135,11 +135,15 @@ impl Writer {
         Ok(())
     }
 
-    pub async fn flush_and_sync(&mut self) -> Result<()> {
+    pub async fn flush_and_sync(&mut self, rolleded: bool) -> Result<()> {
         let mut inner = self.inner.lock().await;
         inner.write_pending().await?;
         inner.w.flush().await?;
-        inner.w.sync_all().await?;
+        if rolleded {
+            inner.w.sync_all().await?;
+        } else {
+            inner.w.sync_data().await?;
+        }
         Ok(())
     }
 

--- a/src/object-engine/lsmstore/src/versions/manifest.rs
+++ b/src/object-engine/lsmstore/src/versions/manifest.rs
@@ -53,6 +53,7 @@ use crate::*;
 
 const BLOCK_SIZE: usize = 32 * 1024;
 const HEADER_SIZE: usize = 7;
+#[allow(dead_code)]
 pub const MAX_FILE_SIZE: usize = 128 << 20;
 
 pub const CRC: Crc<u32> = Crc::<u32>::new(&CRC_32_ISCSI);
@@ -142,6 +143,7 @@ impl Writer {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub async fn accumulated_size(&self) -> usize {
         let inner = self.inner.lock().await;
         inner.written_block_cnt as usize * BLOCK_SIZE + inner.chunk_end

--- a/src/object-engine/lsmstore/src/versions/mod.rs
+++ b/src/object-engine/lsmstore/src/versions/mod.rs
@@ -29,7 +29,7 @@ mod test_version_set {
     async fn test_new_create() -> Result<()> {
         let tmp = tempdir::TempDir::new("test3")?.into_path();
         print!("{:?}", &tmp);
-        let vs1 = VersionSet::new(&tmp, "t1").await?;
+        let vs1 = VersionSet::open(&tmp, "t1").await?;
 
         for i in 1..200 {
             vs1.log_and_apply(
@@ -42,7 +42,7 @@ mod test_version_set {
             .await?;
         }
 
-        let vs2 = VersionSet::new(&tmp, "t1").await?;
+        let vs2 = VersionSet::open(&tmp, "t1").await?;
         for i in 200..400 {
             vs2.log_and_apply(
                 VersionEditBuilder::default()

--- a/src/object-engine/lsmstore/src/versions/mod.rs
+++ b/src/object-engine/lsmstore/src/versions/mod.rs
@@ -1,0 +1,59 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod manifest;
+mod proto;
+mod version;
+mod version_set;
+
+pub use self::{version::Version, version_set::VersionSet};
+
+#[cfg(test)]
+mod test_version_set {
+
+    use super::*;
+    use crate::{versions::proto::*, *};
+
+    #[tokio::test]
+    async fn test_new_create() -> Result<()> {
+        let tmp = tempdir::TempDir::new("test3")?.into_path();
+        print!("{:?}", &tmp);
+        let vs1 = VersionSet::new(&tmp, "t1").await?;
+
+        for i in 1..200 {
+            vs1.log_and_apply(
+                VersionEditBuilder::default()
+                    .add_buckets(vec![version_edit::Bucket {
+                        name: format!("b{}", i).to_string(),
+                    }])
+                    .build(),
+            )
+            .await?;
+        }
+
+        let vs2 = VersionSet::new(&tmp, "t1").await?;
+        for i in 200..400 {
+            vs2.log_and_apply(
+                VersionEditBuilder::default()
+                    .add_buckets(vec![version_edit::Bucket {
+                        name: format!("b{}", i).to_string(),
+                    }])
+                    .build(),
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/object-engine/lsmstore/src/versions/proto.rs
+++ b/src/object-engine/lsmstore/src/versions/proto.rs
@@ -1,0 +1,72 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+tonic::include_proto!("objectengine.manifest.v1");
+
+#[derive(Default)]
+pub struct VersionEditBuilder {
+    ve: VersionEdit,
+}
+
+#[allow(dead_code)]
+impl VersionEditBuilder {
+    pub fn add_buckets(&mut self, buckets: Vec<version_edit::Bucket>) -> &mut Self {
+        self.ve.add_buckets.extend(buckets);
+        self
+    }
+
+    pub fn remove_buckets(&mut self, buckets: Vec<String>) -> &mut Self {
+        self.ve.remove_buckets.extend(buckets);
+        self
+    }
+
+    pub fn add_ranges(&mut self, ranges: Vec<version_edit::Range>) -> &mut Self {
+        self.ve.add_ranges.extend(ranges);
+        self
+    }
+
+    pub fn remove_ranges(&mut self, range: Vec<version_edit::RangeId>) -> &mut Self {
+        self.ve.remove_ranges.extend(range);
+        self
+    }
+
+    pub fn add_files(&mut self, files: Vec<version_edit::File>) -> &mut Self {
+        self.ve.add_files.extend(files);
+        self
+    }
+
+    pub fn remove_files(&mut self, files: Vec<version_edit::FileId>) -> &mut Self {
+        self.ve.remove_files.extend(files);
+        self
+    }
+
+    pub fn add_metas(&mut self, metas: Vec<version_edit::MetaEntry>) -> &mut Self {
+        self.ve.add_metas.extend(metas);
+        self
+    }
+
+    pub fn remove_metas(&mut self, metas: Vec<String>) -> &mut Self {
+        self.ve.remove_metas.extend(metas);
+        self
+    }
+
+    pub fn set_next_file_num(&mut self, next_file_num: u64) -> &mut Self {
+        self.ve.next_file_num = next_file_num;
+        self
+    }
+
+    pub fn build(&self) -> VersionEdit {
+        self.ve.to_owned()
+    }
+}

--- a/src/object-engine/lsmstore/src/versions/version.rs
+++ b/src/object-engine/lsmstore/src/versions/version.rs
@@ -1,0 +1,174 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::{btree_map, BTreeMap},
+    sync::Arc,
+};
+
+use tokio::sync::Mutex;
+
+use crate::{versions::proto::*, *};
+
+const NUM_LEVELS: usize = 7;
+
+type Key = Vec<u8>;
+
+#[derive(Clone)]
+pub struct FileMetadata {
+    pub name: String,
+    pub bucket: String,
+    pub level: u32,
+    pub smallest: Key,
+    pub largest: Key,
+}
+
+type LevelFiles = BTreeMap<Key, FileMetadata>; // smallest_key => FileMetadata
+type BucketLevels = Vec<LevelFiles>; // level -> level files
+
+#[derive(Clone)]
+pub struct BucketVersion {
+    pub levels: BucketLevels,                  // level + key -> file (for read)
+    pub files: BTreeMap<String, FileMetadata>, // filename -> file (for delete)
+}
+
+impl Default for BucketVersion {
+    fn default() -> Self {
+        let levels = (0..NUM_LEVELS)
+            .into_iter()
+            .map(|_| BTreeMap::new())
+            .collect();
+        let files = BTreeMap::new();
+        Self { levels, files }
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct Version {
+    pub inner: Arc<Mutex<Inner>>,
+}
+
+#[derive(Default)]
+pub struct Inner {
+    pub buckets: BTreeMap<String, BucketVersion>, // bucket => levels;
+}
+
+impl Version {
+    pub async fn apply(&mut self, ve: &VersionEdit) -> Result<()> {
+        let mut inner = self.inner.lock().await;
+        inner.apply(ve).await?;
+        Ok(())
+    }
+
+    pub async fn generate_snapshot(&self, next_file_num: u64) -> VersionEdit {
+        let inner = self.inner.lock().await;
+        inner.generate_snapshot(next_file_num).await
+    }
+
+    pub async fn bucket_version(&self, bucket: &str) -> Result<BucketVersion> {
+        let inner = self.inner.lock().await;
+        Ok(inner
+            .buckets
+            .get(bucket)
+            .ok_or_else(|| Error::NotFound(format!("bucket {}", bucket)))?
+            .to_owned())
+    }
+}
+
+impl Inner {
+    async fn apply(&mut self, ve: &VersionEdit) -> Result<()> {
+        for add_bucket in &ve.add_buckets {
+            match self.buckets.entry(add_bucket.name.to_owned()) {
+                btree_map::Entry::Vacant(ent) => Some(ent.insert(BucketVersion::default())),
+                btree_map::Entry::Occupied(_) => None,
+            };
+        }
+        for bucket in &ve.remove_buckets {
+            self.buckets.remove(bucket);
+        }
+
+        for add_file in &ve.add_files {
+            if let Some(bucket) = self.buckets.get_mut(&add_file.bucket) {
+                let file_meta = FileMetadata {
+                    name: add_file.name.to_owned(),
+                    bucket: add_file.bucket.to_owned(),
+                    level: add_file.level,
+                    smallest: add_file.smallest.to_owned(),
+                    largest: add_file.largest.to_owned(),
+                };
+
+                match bucket.files.entry(add_file.name.to_owned()) {
+                    btree_map::Entry::Vacant(ent) => {
+                        ent.insert(file_meta.to_owned());
+                    }
+                    btree_map::Entry::Occupied(_) => {
+                        return Err(Error::AlreadyExists(format!(
+                            "bucket {}, file {}",
+                            &add_file.bucket, &add_file.name
+                        )))
+                    }
+                };
+                let files = bucket
+                    .levels
+                    .get_mut(add_file.level as usize)
+                    .ok_or_else(|| Error::Internal("current version not found".to_string()))?;
+                match files.entry(add_file.smallest.to_owned()) {
+                    btree_map::Entry::Vacant(ent) => {
+                        ent.insert(file_meta);
+                    }
+                    btree_map::Entry::Occupied(_) => {
+                        return Err(Error::AlreadyExists(format!(
+                            "bucket {}, level {}, key {:?}",
+                            &add_file.bucket, &add_file.level, &add_file.smallest
+                        )))
+                    }
+                }
+            } else {
+                return Err(Error::NotFound(format!("bucket {}", &add_file.bucket)));
+            }
+        }
+        for file in &ve.remove_files {
+            if let Some(bucket) = self.buckets.get_mut(&file.bucket) {
+                let removed = bucket.files.remove(&file.name);
+                if let Some(f) = removed {
+                    bucket.levels[f.level as usize].remove(&f.smallest);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn generate_snapshot(&self, next_file_num: u64) -> VersionEdit {
+        let mut b = VersionEditBuilder::default();
+        let mut buckets = Vec::new();
+        for (name, bucket) in &self.buckets {
+            buckets.push(version_edit::Bucket {
+                name: name.to_owned(),
+            });
+            for file in bucket.files.values() {
+                b.add_files(vec![version_edit::File {
+                    range_id: 1,
+                    bucket: file.bucket.to_owned(),
+                    name: file.name.to_owned(),
+                    level: file.level,
+                    smallest: file.smallest.to_owned(),
+                    largest: file.largest.to_owned(),
+                }]);
+            }
+        }
+        b.set_next_file_num(next_file_num);
+        b.build()
+    }
+}

--- a/src/object-engine/lsmstore/src/versions/version_set.rs
+++ b/src/object-engine/lsmstore/src/versions/version_set.rs
@@ -36,7 +36,7 @@ struct Inner {
 }
 
 impl VersionSet {
-    pub async fn new(base_dir: impl Into<PathBuf>, tenant: &str) -> Result<Self> {
+    pub async fn open(base_dir: impl Into<PathBuf>, tenant: &str) -> Result<Self> {
         let mut inner = Inner {
             tenant: tenant.to_owned(),
             base_dir: base_dir.into(),

--- a/src/object-engine/lsmstore/src/versions/version_set.rs
+++ b/src/object-engine/lsmstore/src/versions/version_set.rs
@@ -84,7 +84,7 @@ impl VersionSet {
 
         let mut manifest = inner.manifest.take().unwrap();
         manifest.append(&ve.encode_to_vec()).await?;
-        manifest.flush_and_sync().await?;
+        manifest.flush_and_sync(rolleded).await?;
         inner.manifest = Some(manifest);
         if rolleded {
             inner.update_current(inner.current_file_num).await?;
@@ -148,7 +148,7 @@ impl Inner {
         self.create_manifest(self.current_file_num, next_file_num)
             .await?;
         let mut manifest = self.manifest.take().unwrap();
-        manifest.flush_and_sync().await?;
+        manifest.flush_and_sync(true).await?;
         self.manifest = Some(manifest);
         self.update_current(self.current_file_num).await?;
         Ok(())

--- a/src/object-engine/lsmstore/src/versions/version_set.rs
+++ b/src/object-engine/lsmstore/src/versions/version_set.rs
@@ -65,6 +65,7 @@ impl VersionSet {
         inner.current_version()
     }
 
+    #[allow(dead_code)]
     pub async fn log_and_apply(&self, ve: VersionEdit) -> Result<()> {
         let mut inner = self.inner.lock().await;
 

--- a/src/object-engine/lsmstore/src/versions/version_set.rs
+++ b/src/object-engine/lsmstore/src/versions/version_set.rs
@@ -1,0 +1,241 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::VecDeque, io, path::PathBuf, sync::Arc};
+
+use prost::Message;
+use tokio::{fs, io::AsyncWriteExt, sync::Mutex};
+
+use crate::{
+    versions::{proto::*, version::Version, *},
+    *,
+};
+
+pub struct VersionSet {
+    inner: Arc<Mutex<Inner>>,
+}
+
+struct Inner {
+    tenant: String,
+    base_dir: PathBuf,
+    versions: VecDeque<Version>,
+    manifest: Option<manifest::Writer>,
+    next_file_num: u64,
+    current_file_num: u64,
+}
+
+impl VersionSet {
+    pub async fn new(base_dir: impl Into<PathBuf>, tenant: &str) -> Result<Self> {
+        let mut inner = Inner {
+            tenant: tenant.to_owned(),
+            base_dir: base_dir.into(),
+            versions: VecDeque::new(),
+            manifest: None,
+            next_file_num: 0,
+            current_file_num: 0,
+        };
+        match inner.find_current_manifest().await? {
+            Some(last_file_num) => {
+                inner.load(last_file_num).await?;
+            }
+            None => {
+                inner.create().await?;
+            }
+        }
+        Ok(Self {
+            inner: Arc::new(Mutex::new(inner)),
+        })
+    }
+}
+
+impl VersionSet {
+    pub async fn current_version(&self) -> Version {
+        let inner = self.inner.lock().await;
+        inner.current_version()
+    }
+
+    pub async fn log_and_apply(&self, ve: VersionEdit) -> Result<()> {
+        let mut inner = self.inner.lock().await;
+
+        let rolleded = if match &inner.manifest {
+            Some(manifest) => manifest.accumulated_size().await > manifest::MAX_FILE_SIZE,
+            None => true, // new or restarted
+        } {
+            let new_file_num = inner.get_next_file_num();
+            let next_file_num = inner.next_file_num;
+            inner.create_manifest(new_file_num, next_file_num).await?;
+            inner.current_file_num = new_file_num;
+            true
+        } else {
+            false
+        };
+
+        let mut manifest = inner.manifest.take().unwrap();
+        manifest.append(&ve.encode_to_vec()).await?;
+        manifest.flush_and_sync().await?;
+        inner.manifest = Some(manifest);
+        if rolleded {
+            inner.update_current(inner.current_file_num).await?;
+        }
+
+        let mut new_version = inner.current_version().to_owned();
+        new_version.apply(&ve).await?;
+
+        inner.versions.push_back(new_version);
+
+        Ok(())
+    }
+}
+
+impl Inner {
+    fn get_next_file_num(&mut self) -> u64 {
+        let num = self.next_file_num;
+        self.next_file_num += 1;
+        num
+    }
+
+    fn current_version(&self) -> Version {
+        self.versions.back().unwrap().to_owned()
+    }
+
+    async fn create_manifest(&mut self, create_file_num: u64, next_file_num: u64) -> Result<()> {
+        let file = {
+            let filename = self.file_path(create_file_num);
+            fs::create_dir_all(filename.parent().unwrap()).await?;
+            fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .write(true)
+                .open(filename)
+                .await?
+        };
+        let mut writer = manifest::Writer::new(file);
+
+        let snapshot = self
+            .current_version()
+            .generate_snapshot(next_file_num)
+            .await;
+
+        writer.append(&snapshot.encode_to_vec()).await?;
+
+        self.manifest = Some(writer);
+        Ok(())
+    }
+
+    fn file_path(&self, manifest_file_name: u64) -> PathBuf {
+        self.base_dir
+            .join(&self.tenant)
+            .join(format!("MANIFEST-{}", manifest_file_name))
+    }
+
+    async fn create(&mut self) -> Result<()> {
+        let new_version = Version::default();
+        self.versions.push_back(new_version);
+        self.current_file_num = self.get_next_file_num();
+        let next_file_num = self.next_file_num;
+        self.create_manifest(self.current_file_num, next_file_num)
+            .await?;
+        let mut manifest = self.manifest.take().unwrap();
+        manifest.flush_and_sync().await?;
+        self.manifest = Some(manifest);
+        self.update_current(self.current_file_num).await?;
+        Ok(())
+    }
+
+    async fn load(&mut self, manifest_file_num: u64) -> Result<()> {
+        self.current_file_num = manifest_file_num;
+        let manifest_file = {
+            let filename = self.file_path(self.current_file_num);
+            fs::create_dir_all(filename.parent().unwrap()).await?;
+            fs::OpenOptions::new()
+                .create(false)
+                .append(true)
+                .read(true)
+                .open(filename)
+                .await?
+        };
+
+        let mut new_version = Version::default();
+        let mut r = manifest::Reader::new(manifest_file);
+        loop {
+            let res = r.read().await;
+            if let Err(Error::Io(err)) = &res {
+                if Self::is_eof(err) {
+                    break;
+                }
+            }
+            let chunk_data = res?;
+            let ve = VersionEdit::decode(chunk_data.as_slice()).unwrap();
+            if ve.next_file_num > 0 {
+                self.next_file_num = ve.next_file_num;
+            }
+            new_version.apply(&ve).await?;
+        }
+        self.versions.push_back(new_version);
+        Ok(())
+    }
+
+    fn is_eof(err: &io::Error) -> bool {
+        err.kind() == io::ErrorKind::UnexpectedEof
+    }
+
+    async fn find_current_manifest(&self) -> Result<Option<u64>> {
+        let path = self.base_dir.join(&self.tenant).join("CURRENT");
+        let res = fs::read_to_string(&path).await;
+        if let Err(io_err) = &res {
+            if io_err.kind() == std::io::ErrorKind::NotFound {
+                return Ok(None);
+            }
+        }
+        let content = res?;
+        if !content.ends_with('\n') {
+            return Err(Error::Corrupted("invalid CURRENT".to_string()));
+        }
+        let manifest_name = content.trim().split_once('-');
+        if manifest_name.is_none() {
+            return Err(Error::Corrupted("invalid CURRENT".to_string()));
+        }
+        let (prefix, num) = manifest_name.unwrap();
+        if prefix != "MANIFEST" {
+            return Err(Error::Corrupted("invalid CURRENT".to_string()));
+        }
+        let num = num.parse::<u64>();
+        if num.is_err() {
+            return Err(Error::Corrupted("invalid CURRENT".to_string()));
+        }
+        Ok(Some(num.unwrap()))
+    }
+
+    async fn update_current(&self, file_num: u64) -> Result<()> {
+        let tmp_path = self
+            .base_dir
+            .join(&self.tenant)
+            .join(format!("CURRENT.{}.dbtmp", file_num));
+        let curr_path = self.base_dir.join(&self.tenant).join("CURRENT");
+        let _ = fs::remove_file(&tmp_path).await;
+        {
+            let mut tmp_w = fs::OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .open(&tmp_path)
+                .await?;
+            tmp_w
+                .write_all(format!("MANIFEST-{}\n", file_num).as_bytes())
+                .await?;
+            tmp_w.sync_all().await?;
+        }
+        fs::rename(tmp_path, curr_path).await?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
ref #556 's first task

Implement a local disk-based manifest that will be used in lsmstore