### PR TITLE
object-engine: implement iterators in lsmstore

### DIFF
--- a/src/object-engine/filestore/src/lib.rs
+++ b/src/object-engine/filestore/src/lib.rs
@@ -18,6 +18,10 @@ pub mod fs;
 
 use object_engine_common::{async_trait, Error, Result};
 
-pub use self::store::{
-    Bucket, FileDesc, Lister, RandomRead, SequentialRead, SequentialWrite, Store, Tenant,
+pub use self::{
+    fs::Store as FsFileStore,
+    store::{
+        copy_all, Bucket, FileDesc, Lister, RandomRead, SequentialRead, SequentialWrite, Store,
+        Tenant,
+    },
 };

--- a/src/object-engine/filestore/src/store.rs
+++ b/src/object-engine/filestore/src/store.rs
@@ -80,3 +80,20 @@ pub trait SequentialWrite: Send {
 
     async fn finish(&mut self) -> Result<()>;
 }
+
+const COPY_BUFFER_SIZE: usize = 8 * 1024;
+
+pub async fn copy_all(
+    mut r: Box<dyn SequentialRead>,
+    mut w: Box<dyn SequentialWrite>,
+) -> Result<()> {
+    let mut buf = vec![0; COPY_BUFFER_SIZE];
+    loop {
+        let n = r.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        w.write(&buf[..n]).await?;
+    }
+    Ok(())
+}

--- a/src/object-engine/lsmstore/proto/manifest.proto
+++ b/src/object-engine/lsmstore/proto/manifest.proto
@@ -28,8 +28,8 @@ message VersionEdit {
   message Range {
     uint64 id = 1;
     string bucket = 2;
-    bytes smallest = 3;
-    bytes largest = 4;
+    bytes lower_bound = 3;
+    bytes upper_bound = 4;
   }
 
   message RangeID {
@@ -41,12 +41,14 @@ message VersionEdit {
   repeated RangeID remove_ranges = 5;
 
   message File {
-    string bucket = 1;
-    uint64 range_id = 2;
-    string name = 3;
-    uint32 level = 4;
-    bytes smallest = 5;
-    bytes largest = 6;
+    string tenant = 1;
+    string bucket = 2;
+    uint64 range_id = 3;
+    string name = 4;
+    uint32 level = 5;
+    bytes lower_bound = 6;
+    bytes upper_bound = 7;
+    uint64 file_size = 8;
   };
 
   message FileID {

--- a/src/object-engine/lsmstore/src/iterator/level_iter.rs
+++ b/src/object-engine/lsmstore/src/iterator/level_iter.rs
@@ -1,0 +1,139 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use object_engine_filestore::Store as FileStore;
+
+use crate::{iterator::ManifestIter, versions::FileMetadata, *};
+
+pub struct LevelIter {
+    tenant: String,
+    bucket: String,
+    local_store: Arc<dyn FileStore>,
+
+    manifest_file_iter: ManifestIter,
+    current_file: Option<FileMetadata>,
+    current_iter: Option<TableIter>,
+
+    init: bool,
+}
+
+impl LevelIter {
+    pub async fn new(
+        tenant: &str,
+        bucket: &str,
+        manifest_file_iter: ManifestIter,
+        local_store: Arc<dyn FileStore>,
+    ) -> Result<Self> {
+        let mut iter = Self {
+            tenant: tenant.to_owned(),
+            bucket: bucket.to_owned(),
+            manifest_file_iter,
+            current_file: None,
+            current_iter: None,
+            local_store,
+            init: false,
+        };
+        iter.seek_to_first().await?;
+        Ok(iter)
+    }
+
+    pub fn key(&self) -> Option<Key<'_>> {
+        debug_assert!(self.valid());
+        self.current_iter.as_ref().map(|e| e.key())
+    }
+
+    pub fn value(&self) -> &[u8] {
+        debug_assert!(self.valid());
+        self.current_iter.as_ref().unwrap().value()
+    }
+
+    pub fn valid(&self) -> bool {
+        !self.init
+            || (self.current_file.is_some()
+                && self.current_iter.is_some()
+                && self.current_iter.as_ref().unwrap().valid())
+    }
+
+    pub async fn seek_to_first(&mut self) -> Result<()> {
+        self.manifest_file_iter.seek_to_first();
+        if !self.manifest_file_iter.valid() {
+            return Ok(());
+        }
+        self.current_file = Some(self.manifest_file_iter.value());
+        let file_metadata = self.current_file.as_ref().unwrap();
+        self.current_iter = Some(
+            self.open_table_iter(&file_metadata.name, file_metadata.file_size as usize)
+                .await?,
+        );
+        self.current_iter.as_mut().unwrap().seek_to_first().await?;
+        if !self.init {
+            self.init = true;
+        }
+        Ok(())
+    }
+
+    pub async fn seek(&mut self, target: Key<'_>) -> Result<()> {
+        self.manifest_file_iter.seek(target);
+        if !self.manifest_file_iter.valid() {
+            return Ok(());
+        }
+        self.set_current_tbl_iter().await?;
+        self.current_iter.as_mut().unwrap().seek(target).await?;
+        if !self.init {
+            self.init = true;
+        }
+        Ok(())
+    }
+
+    pub async fn next(&mut self) -> Result<()> {
+        if !self.init {
+            self.manifest_file_iter.seek_to_first();
+            if !self.manifest_file_iter.valid() {
+                return Ok(());
+            }
+            self.set_current_tbl_iter().await?;
+            self.current_iter.as_mut().unwrap().seek_to_first().await?;
+        } else if !self.current_iter.as_ref().unwrap().valid() {
+            self.manifest_file_iter.next();
+            if !self.manifest_file_iter.valid() {
+                return Ok(());
+            }
+            self.set_current_tbl_iter().await?;
+            self.current_iter.as_mut().unwrap().seek_to_first().await?;
+        } else {
+            self.current_iter.as_mut().unwrap().next().await?;
+        }
+        Ok(())
+    }
+
+    async fn set_current_tbl_iter(&mut self) -> Result<()> {
+        self.current_file = Some(self.manifest_file_iter.value());
+        let f = self.current_file.as_ref().unwrap();
+        self.current_iter = Some(self.open_table_iter(&f.name, f.file_size as usize).await?);
+        Ok(())
+    }
+
+    async fn open_table_iter(&self, file: &str, file_size: usize) -> Result<TableIter> {
+        let r = self
+            .local_store
+            .tenant(&self.tenant)
+            .bucket(&self.bucket)
+            .new_random_reader(file)
+            .await?;
+        let tr = TableReader::open(r.into(), file_size).await?;
+        Ok(tr.iter())
+    }
+}

--- a/src/object-engine/lsmstore/src/iterator/manifest_iter.rs
+++ b/src/object-engine/lsmstore/src/iterator/manifest_iter.rs
@@ -1,0 +1,99 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{collections::BTreeSet, ops::Bound::*};
+
+use crate::{
+    versions::{FileMetadata, OrdByUpperBound},
+    Key,
+};
+
+pub struct ManifestIter {
+    files: BTreeSet<OrdByUpperBound>,
+    current: Option<OrdByUpperBound>,
+    init: bool,
+}
+
+impl ManifestIter {
+    pub fn new(files: BTreeSet<OrdByUpperBound>) -> Self {
+        let mut last_upper_bound = None;
+        for f in &files {
+            if let Some(last) = last_upper_bound {
+                assert!(f.lower_bound > last)
+            }
+            last_upper_bound = Some(f.upper_bound.to_owned());
+        }
+        Self {
+            files,
+            current: None,
+            init: false,
+        }
+    }
+
+    pub fn key(&self) -> Key<'_> {
+        debug_assert!(self.valid());
+        self.current.as_ref().unwrap().upper_bound.as_slice().into()
+    }
+
+    pub fn value(&self) -> FileMetadata {
+        debug_assert!(self.valid());
+        self.current.as_ref().cloned().unwrap().0
+    }
+
+    pub fn valid(&self) -> bool {
+        !self.init || self.current.is_some()
+    }
+
+    pub fn seek_to_first(&mut self) {
+        self.current = self.files.first().cloned();
+        if !self.init {
+            self.init = true;
+        }
+    }
+
+    pub fn seek(&mut self, target: Key<'_>) {
+        self.current = self
+            .files
+            .range((
+                Included(OrdByUpperBound(FileMetadata {
+                    upper_bound: target.to_owned(),
+                    ..Default::default()
+                })),
+                Unbounded,
+            ))
+            .next()
+            .cloned();
+        if !self.init {
+            self.init = true;
+        }
+    }
+
+    pub fn next(&mut self) {
+        if !self.init {
+            self.seek_to_first();
+            self.init = true
+        }
+        self.current = self
+            .files
+            .range((
+                Excluded(OrdByUpperBound(FileMetadata {
+                    upper_bound: self.current.as_ref().unwrap().upper_bound.to_owned(),
+                    ..Default::default()
+                })),
+                Unbounded,
+            ))
+            .next()
+            .cloned()
+    }
+}

--- a/src/object-engine/lsmstore/src/iterator/merging_iter.rs
+++ b/src/object-engine/lsmstore/src/iterator/merging_iter.rs
@@ -1,0 +1,193 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    cmp::{Ordering, Reverse},
+    collections::BinaryHeap,
+};
+
+use crate::{iterator::LevelIter, Key, Result, Timestamp, ValueType};
+
+pub struct MergingIterator {
+    pub levels: Vec<LevelIter>,
+    pub iter_heap: BinaryHeap<Reverse<HeapItem>>,
+
+    pub init: bool,
+    pub snapshot: Option<Timestamp>,
+}
+
+impl MergingIterator {
+    pub fn new(levels: Vec<LevelIter>, snapshot: Option<u64>) -> Self {
+        let iter_heap = BinaryHeap::with_capacity(levels.len());
+        Self {
+            levels,
+            iter_heap,
+            init: false,
+            snapshot,
+        }
+    }
+
+    pub fn key(&self) -> Key<'_> {
+        debug_assert!(self.valid());
+        let (k, _) = self.current_entry().unwrap();
+        k
+    }
+
+    pub fn value(&self) -> &[u8] {
+        debug_assert!(self.valid());
+        let (_, v) = self.current_entry().unwrap();
+        v
+    }
+
+    pub fn valid(&self) -> bool {
+        if !self.init {
+            return true;
+        }
+        if let Some(iter) = self.iter_heap.peek() {
+            return self.levels[iter.0.index].valid();
+        }
+        false
+    }
+
+    pub async fn seek_to_first(&mut self) -> Result<()> {
+        for l in self.levels.iter_mut() {
+            l.seek_to_first().await?;
+        }
+        self.init_heap();
+        if !self.init {
+            self.init = true
+        }
+        self.seek_to_next_visible().await?;
+        Ok(())
+    }
+
+    pub async fn seek(&mut self, target: Key<'_>) -> Result<()> {
+        for l in self.levels.iter_mut() {
+            l.seek(target).await?;
+        }
+        self.init_heap();
+        if !self.init {
+            self.init = true
+        }
+        self.seek_to_next_visible().await?;
+        Ok(())
+    }
+
+    pub async fn next(&mut self) -> Result<()> {
+        if !self.init {
+            self.seek_to_first().await?;
+            return Ok(());
+        }
+
+        self.next_entry().await?;
+        self.seek_to_next_visible().await?;
+        Ok(())
+    }
+
+    fn init_heap(&mut self) {
+        self.iter_heap.clear();
+        for (index, iter) in self.levels.iter().enumerate() {
+            if !iter.valid() {
+                continue;
+            }
+            if let Some(key) = iter.key() {
+                self.iter_heap.push(Reverse(HeapItem {
+                    index,
+                    key: key.to_owned(),
+                }));
+            }
+        }
+    }
+
+    async fn next_entry(&mut self) -> Result<()> {
+        let prev_smallest = self.iter_heap.peek();
+        if prev_smallest.is_none() {
+            return Ok(());
+        }
+
+        let prev_level_iter = &mut self.levels[prev_smallest.unwrap().0.index];
+        prev_level_iter.next().await?;
+
+        if prev_level_iter.valid() {
+            if !prev_level_iter.valid() {
+                print!("")
+            }
+            self.iter_heap.peek_mut().unwrap().0.key = prev_level_iter.key().unwrap().to_owned();
+            let item = self.iter_heap.pop().unwrap();
+            self.iter_heap.push(item)
+        } else {
+            self.iter_heap.pop();
+        }
+        Ok(())
+    }
+
+    async fn seek_to_next_visible(&mut self) -> Result<()> {
+        while !self.iter_heap.is_empty() {
+            let level = &self.iter_heap.peek().unwrap().0;
+            let key = Key::from(level.key.as_slice());
+
+            if self.check_key_visible(key) {
+                match key.tp() {
+                    ValueType::Put | ValueType::Merge => return Ok(()),
+                    ValueType::Delete => {}
+                }
+            }
+            self.next_entry().await?;
+        }
+        Ok(())
+    }
+
+    fn check_key_visible(&self, key: Key<'_>) -> bool {
+        if let Some(snapshot) = self.snapshot {
+            return key.ts() <= snapshot;
+        }
+        true
+    }
+
+    fn current_entry(&self) -> Option<(Key<'_>, &[u8])> {
+        if self.iter_heap.is_empty() {
+            return None;
+        }
+        if let Some(item) = self.iter_heap.peek() {
+            let l = &self.levels[item.0.index];
+            let key = l.key()?;
+            return Some((key, l.value()));
+        }
+        None
+    }
+}
+
+#[derive(Eq)]
+pub struct HeapItem {
+    index: usize,
+    key: Vec<u8>,
+}
+
+impl Ord for HeapItem {
+    fn cmp(&self, other: &Self) -> Ordering {
+        Key::from(self.key.as_slice()).cmp(&Key::from(other.key.as_slice()))
+    }
+}
+
+impl PartialOrd for HeapItem {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for HeapItem {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key
+    }
+}

--- a/src/object-engine/lsmstore/src/iterator/mod.rs
+++ b/src/object-engine/lsmstore/src/iterator/mod.rs
@@ -12,32 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::Result;
+mod level_iter;
+mod manifest_iter;
+mod merging_iter;
 
-pub struct BucketIter {}
-
-impl BucketIter {
-    pub fn id(&self) -> &[u8] {
-        todo!();
-    }
-
-    pub fn value(&self) -> &[u8] {
-        todo!();
-    }
-
-    pub fn valid(&self) -> bool {
-        todo!();
-    }
-
-    pub async fn seek_to_first(&mut self) -> Result<()> {
-        todo!();
-    }
-
-    pub async fn seek(&mut self, _target: &[u8]) -> Result<()> {
-        todo!();
-    }
-
-    pub async fn next(&mut self) -> Result<()> {
-        todo!();
-    }
-}
+pub use self::{level_iter::LevelIter, manifest_iter::ManifestIter, merging_iter::MergingIterator};

--- a/src/object-engine/lsmstore/src/lib.rs
+++ b/src/object-engine/lsmstore/src/lib.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod bucket_iter;
+#![feature(map_first_last)]
+
+mod iterator;
 mod store;
 mod table;
 mod versions;
@@ -20,10 +22,13 @@ mod versions;
 use object_engine_common::{Error, Result};
 
 pub use self::{
-    bucket_iter::BucketIter,
+    iterator::MergingIterator,
     store::{Bucket, Store, Tenant},
     table::{
         Key, TableBuilder, TableBuilderOptions, TableDesc, TableIter, TableReader, Timestamp,
         ValueType,
+    },
+    versions::{
+        Bucket as VersionEditBucket, File as VersionEditFile, VersionEditBuilder, VersionSet,
     },
 };

--- a/src/object-engine/lsmstore/src/store.rs
+++ b/src/object-engine/lsmstore/src/store.rs
@@ -13,15 +13,22 @@
 // limitations under the License.
 
 use std::{
-    collections::{hash_map, HashMap},
+    collections::{hash_map, BTreeSet, HashMap},
+    ops::Deref,
     path::PathBuf,
     sync::Arc,
 };
 
+use object_engine_filestore::{SequentialWrite, Store as FileStore};
 use tokio::sync::Mutex;
 
-use crate::{versions::VersionSet, BucketIter, Error, Result};
+use crate::{
+    iterator::{LevelIter, ManifestIter, MergingIterator},
+    versions::{proto::*, BucketVersion, OrdByUpperBound, VersionSet},
+    Error, Key, Result, TableReader, ValueType, VersionEditBuilder, VersionEditFile,
+};
 
+#[derive(Clone)]
 pub struct Store {
     inner: Arc<Mutex<Inner>>,
 }
@@ -29,13 +36,21 @@ pub struct Store {
 struct Inner {
     base_dir: PathBuf,
     version_sets: HashMap<String, VersionSet>, // tenant -> VersionSet
+    local_store: Option<Arc<dyn FileStore>>,
+    external_store: Arc<dyn FileStore>,
 }
 
 impl Store {
-    pub async fn new(base_dir: impl Into<PathBuf>) -> Result<Self> {
+    pub async fn new(
+        base_dir: impl Into<PathBuf>,
+        local_store: Option<Arc<dyn FileStore>>,
+        external_store: Arc<dyn FileStore>,
+    ) -> Result<Self> {
         let inner = Inner {
             base_dir: base_dir.into(),
             version_sets: HashMap::new(),
+            local_store,
+            external_store,
         };
         Ok(Self {
             inner: Arc::new(Mutex::new(inner)),
@@ -48,13 +63,18 @@ impl Store {
         match inner.version_sets.entry(name.to_owned()) {
             hash_map::Entry::Occupied(_) => {}
             hash_map::Entry::Vacant(ent) => {
-                ent.insert(VersionSet::open(base_dir, name).await?);
+                ent.insert(VersionSet::open(base_dir.join(name)).await?);
             }
         }
         Ok(Tenant {
             tenant: name.to_owned(),
             inner: self.inner.clone(),
         })
+    }
+
+    pub async fn create_tenant(&self, _name: &str) -> Result<()> {
+        // TODO: save tenant info in some place.
+        Ok(())
     }
 }
 
@@ -71,6 +91,58 @@ impl Tenant {
             inner: self.inner.clone(),
         })
     }
+
+    pub async fn create_bucket(&self, name: &str) -> Result<()> {
+        let inner = self.inner.lock().await;
+
+        inner
+            .external_store
+            .tenant(&self.tenant)
+            .create_bucket(name)
+            .await?;
+
+        let version_tenant = inner
+            .version_sets
+            .get(&self.tenant)
+            .ok_or_else(|| Error::NotFound(format!("tenant {}", &self.tenant)))?;
+        version_tenant
+            .log_and_apply(
+                VersionEditBuilder::default()
+                    .add_buckets(vec![version_edit::Bucket {
+                        name: name.to_owned(),
+                    }])
+                    .build(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn add_files(&self, files: Vec<VersionEditFile>) -> Result<()> {
+        let inner = self.inner.lock().await;
+
+        let ve = VersionEditBuilder::default()
+            .add_files(files.to_owned())
+            .build();
+        let tenant = inner.version_sets.get(&self.tenant).unwrap();
+        tenant.log_and_apply(ve).await?;
+
+        if inner.local_store.is_some() {
+            for f in &files {
+                let bucket = inner
+                    .local_store
+                    .as_ref()
+                    .unwrap()
+                    .tenant(&self.tenant)
+                    .bucket(&f.bucket);
+
+                let r = bucket.new_sequential_reader(&f.name).await?;
+                let w = bucket.new_sequential_writer(&f.name).await?;
+                object_engine_filestore::copy_all(r, w).await?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 pub struct Bucket {
@@ -80,19 +152,152 @@ pub struct Bucket {
 }
 
 impl Bucket {
-    pub async fn get(&self, _id: &[u8]) -> Result<Option<Vec<u8>>> {
+    pub async fn get(&self, id: &[u8]) -> Result<Option<Vec<u8>>> {
         let inner = self.inner.lock().await;
         let vs = inner
             .version_sets
             .get(&self.tenant)
             .ok_or_else(|| Error::NotFound(format!("tenant {}", &self.tenant)))?;
-        let current = vs.current_version().await;
-        let _current = current.bucket_version(&self.bucket).await?;
-
-        todo!();
+        let current = vs
+            .current_version()
+            .await
+            .bucket_version(&self.bucket)
+            .await?;
+        inner
+            .get(current, &self.tenant, &self.bucket, id, u64::MAX)
+            .await
     }
 
-    pub fn iter(&self) -> BucketIter {
-        BucketIter {}
+    pub async fn iter(&self) -> Result<MergingIterator> {
+        let inner = self.inner.lock().await;
+        let vs = inner
+            .version_sets
+            .get(&self.tenant)
+            .ok_or_else(|| Error::NotFound(format!("tenant {}", &self.tenant)))?;
+        let current = vs
+            .current_version()
+            .await
+            .bucket_version(&self.bucket)
+            .await?;
+
+        let merge_iter = inner
+            .get_merge_iter(&self.tenant, &self.bucket, current)
+            .await?;
+
+        Ok(merge_iter)
+    }
+
+    pub async fn new_sequential_writer(&self, name: &str) -> Result<Box<dyn SequentialWrite>> {
+        let inner = self.inner.lock().await;
+        inner
+            .external_store
+            .tenant(&self.tenant)
+            .bucket(&self.bucket)
+            .new_sequential_writer(name)
+            .await
+    }
+}
+
+impl Inner {
+    fn get_store(&self) -> Arc<dyn FileStore> {
+        if self.local_store.is_none() {
+            self.external_store.clone()
+        } else {
+            self.local_store.as_ref().unwrap().clone()
+        }
+    }
+
+    async fn get(
+        &self,
+        ver: BucketVersion,
+        tenant: &str,
+        bucket: &str,
+        id: &[u8],
+        snapshot_ts: u64,
+    ) -> Result<Option<Vec<u8>>> {
+        let key = Key::encode_to_vec(id, u64::MAX, ValueType::Put);
+        for l in ver.l0_level.iter().rev() {
+            let r = self
+                .get_store()
+                .tenant(tenant)
+                .bucket(bucket)
+                .new_random_reader(&l.name)
+                .await?;
+
+            let mut iter = TableReader::open(r.into(), l.file_size as usize)
+                .await?
+                .iter();
+            iter.seek(key.as_slice().into()).await?;
+            while iter.valid() {
+                let k = iter.key();
+                if k.id() != id {
+                    break;
+                }
+                if k.ts() > snapshot_ts {
+                    continue;
+                }
+                match k.tp() {
+                    ValueType::Put => return Ok(Some(iter.value().to_owned())),
+                    ValueType::Delete => return Ok(None),
+                    ValueType::Merge => todo!(),
+                }
+            }
+        }
+
+        for l in ver.non_l0_levels {
+            let level_file = l.iter();
+            let local_store = self.get_store();
+            let mut iter = LevelIter::new(tenant, bucket, level_file, local_store).await?;
+            iter.seek(key.as_slice().into()).await?;
+            while iter.valid() {
+                let k = iter.key();
+                if k.is_none() {
+                    break;
+                }
+                let k = k.unwrap();
+                if k.id() != key {
+                    break;
+                }
+                if k.ts() > snapshot_ts {
+                    continue;
+                }
+                match k.tp() {
+                    ValueType::Put => return Ok(Some(iter.value().to_owned())),
+                    ValueType::Delete => return Ok(None),
+                    ValueType::Merge => todo!(),
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    async fn get_merge_iter(
+        &self,
+        tenant: &str,
+        bucket: &str,
+        version: BucketVersion,
+    ) -> Result<MergingIterator> {
+        let mut level_iters = Vec::new();
+
+        for l0_file in version.l0_level.iter().rev() {
+            let mut fs = BTreeSet::new();
+            fs.insert(OrdByUpperBound(l0_file.deref().to_owned()));
+            let manifest_file_iter = ManifestIter::new(fs);
+            let local_store = self.get_store();
+            let merge_iter =
+                LevelIter::new(tenant, bucket, manifest_file_iter, local_store).await?;
+            level_iters.push(merge_iter);
+        }
+
+        for level_files in version.non_l0_levels {
+            let manifest_file_iter = level_files.iter();
+            let local_store = self.get_store();
+            let merge_iter =
+                LevelIter::new(tenant, bucket, manifest_file_iter, local_store).await?;
+            level_iters.push(merge_iter);
+        }
+
+        Ok(MergingIterator::new(level_iters, None))
     }
 }

--- a/src/object-engine/lsmstore/src/table/mod.rs
+++ b/src/object-engine/lsmstore/src/table/mod.rs
@@ -20,10 +20,8 @@ mod table_builder;
 mod table_footer;
 mod table_reader;
 
-use self::{
-    block_builder::BlockBuilder, block_handle::BlockHandle, block_iter::BlockIter,
-    table_footer::TableFooter,
-};
+pub(crate) use self::block_iter::BlockIter;
+use self::{block_builder::BlockBuilder, block_handle::BlockHandle, table_footer::TableFooter};
 pub use self::{
     format::{Key, Timestamp, ValueType},
     table_builder::{TableBuilder, TableBuilderOptions, TableDesc},

--- a/src/object-engine/lsmstore/src/table/table_reader.rs
+++ b/src/object-engine/lsmstore/src/table/table_reader.rs
@@ -73,7 +73,7 @@ impl TableIter {
     pub fn valid(&self) -> bool {
         self.block_iter
             .as_ref()
-            .map(|x| x.valid())
+            .map(|e| e.valid())
             .unwrap_or_default()
     }
 
@@ -89,11 +89,11 @@ impl TableIter {
         Ok(())
     }
 
-    pub async fn seek(&mut self, target: Key<'_>) -> Result<()> {
-        self.index_iter.seek(target);
+    pub async fn seek(&mut self, key: Key<'_>) -> Result<()> {
+        self.index_iter.seek(key);
         self.block_iter = if self.index_iter.valid() {
             let mut iter = self.read_block_iter().await?;
-            iter.seek(target);
+            iter.seek(key);
             Some(iter)
         } else {
             None
@@ -141,7 +141,7 @@ impl FileReader {
     }
 
     async fn read_block(&self, handle: &BlockHandle) -> Result<Arc<[u8]>> {
-        let mut buf = Vec::with_capacity(handle.length as usize);
+        let mut buf = vec![0u8; handle.length as usize];
         self.reader.read_exact_at(&mut buf, handle.offset).await?;
         Ok(buf.into())
     }

--- a/src/object-engine/lsmstore/src/versions/mod.rs
+++ b/src/object-engine/lsmstore/src/versions/mod.rs
@@ -13,15 +13,21 @@
 // limitations under the License.
 
 mod manifest;
-mod proto;
+pub mod proto;
 mod version;
 mod version_set;
 
-pub use self::{version::Version, version_set::VersionSet};
+pub use self::{
+    proto::{
+        version_edit::{Bucket, File},
+        VersionEditBuilder,
+    },
+    version::{BucketVersion, FileMetadata, OrdByUpperBound, Version},
+    version_set::VersionSet,
+};
 
 #[cfg(test)]
 mod test_version_set {
-
     use super::*;
     use crate::{versions::proto::*, *};
 
@@ -29,7 +35,7 @@ mod test_version_set {
     async fn test_new_create() -> Result<()> {
         let tmp = tempdir::TempDir::new("test3")?.into_path();
         print!("{:?}", &tmp);
-        let vs1 = VersionSet::open(&tmp, "t1").await?;
+        let vs1 = VersionSet::open(&tmp).await?;
 
         for i in 1..200 {
             vs1.log_and_apply(
@@ -42,7 +48,7 @@ mod test_version_set {
             .await?;
         }
 
-        let vs2 = VersionSet::open(&tmp, "t1").await?;
+        let vs2 = VersionSet::open(&tmp).await?;
         for i in 200..400 {
             vs2.log_and_apply(
                 VersionEditBuilder::default()


### PR DESCRIPTION
ref #556

Implements some iterators for lsm store

- `manifest_iter` to iterate between manifest files in a level
- `level_iter` to iterate sst file in a level by combinate `manifest_iter` and `table_iter`
- `merging_iter` to merge multiple levels result

full usage can be seen in  https://github.com/engula/engula/compare/main...zojw:lsm-rw?expand=1#diff-1593cd134f18c1abca6d47b743a8990e901854c3cdda77454ea77ce0b0e9a017R42