### PR TITLE
server: avoid blocking writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,7 @@ dependencies = [
  "atoi",
  "bytes",
  "engula-engine",
+ "smallvec",
  "thiserror",
  "tokio",
  "tracing",

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -12,6 +12,7 @@ engula-engine = { version = "0.3", path = "../engine" }
 
 atoi = "0.3"
 bytes = "1.0"
+smallvec = "1.8.0"
 thiserror = "1.0"
 tracing = "0.1"
 tokio = { version = "1.17", features = ["full"] }

--- a/src/server/src/lib.rs
+++ b/src/server/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(cursor_remaining)]
+
 use engula_engine::Db;
 
 mod error;


### PR DESCRIPTION
Since awaiting a write requires waiting for the write to complete before doing anything else, this PR removes that restriction.

Now, writes are added to the `reply_buffer` first, and when the buffer is full it tries to write to the kernel. If the socket is busy at this time, save these buffers to `reply_buffer_queue`, and try to write when the socket is writable.