### PR TITLE
fix: wrong number of arguments should not let server crash

### DIFF
--- a/src/server/src/cmd/get.rs
+++ b/src/server/src/cmd/get.rs
@@ -65,7 +65,10 @@ impl Get {
         // input is fully consumed, then an error is returned.
         let key = parse.next_bytes()?;
 
-        Ok(Get { key })
+        match parse.finish() {
+            Ok(()) => Ok(Get { key }),
+            Err(_) => Err("wrong number of arguments for 'get' command".into()),
+        }
     }
 
     /// Apply the `Get` command to the specified `Db` instance.

--- a/src/server/src/cmd/mod.rs
+++ b/src/server/src/cmd/mod.rs
@@ -32,7 +32,7 @@ use crate::{Db, Frame, Parse, ParseError};
 pub fn apply(frame: Frame, db: &Db) -> Frame {
     match Command::from_frame(frame) {
         Ok(cmd) => cmd.apply(db).unwrap(),
-        Err(e) => Frame::Error(format!("ERR {}", e.to_string())),
+        Err(e) => Frame::Error(format!("ERR {}", e)),
     }
 }
 

--- a/src/server/src/cmd/mod.rs
+++ b/src/server/src/cmd/mod.rs
@@ -29,6 +29,13 @@ pub use unknown::Unknown;
 
 use crate::{Db, Frame, Parse, ParseError};
 
+pub fn apply(frame: Frame, db: &Db) -> Frame {
+    match Command::from_frame(frame) {
+        Ok(cmd) => cmd.apply(db).unwrap(),
+        Err(e) => Frame::Error(format!("ERR {}", e.to_string())),
+    }
+}
+
 /// Enumeration of supported Redis commands.
 ///
 /// Methods called on `Command` are delegated to the command implementation.

--- a/src/server/src/cmd/ping.rs
+++ b/src/server/src/cmd/ping.rs
@@ -54,10 +54,15 @@ impl Ping {
     /// PING [message]
     /// ```
     pub(crate) fn parse_frames(parse: &mut Parse) -> crate::Result<Ping> {
-        match parse.next_string() {
-            Ok(msg) => Ok(Ping::new(Some(msg))),
-            Err(ParseError::EndOfStream) => Ok(Ping::default()),
-            Err(e) => Err(e.into()),
+        let cmd = match parse.next_string() {
+            Ok(msg) => Ping::new(Some(msg)),
+            Err(ParseError::EndOfStream) => Ping::default(),
+            Err(e) => return Err(e.into()),
+        };
+
+        match parse.finish() {
+            Ok(()) => Ok(cmd),
+            Err(_) => Err("wrong number of arguments for 'ping' command".into()),
         }
     }
 

--- a/src/server/src/error.rs
+++ b/src/server/src/error.rs
@@ -26,7 +26,7 @@ pub enum Error {
     Frame(#[from] FrameError),
     #[error(transparent)]
     Parse(#[from] ParseError),
-    #[error("unknown error: {0}")]
+    #[error("{0}")]
     Unknown(String),
 }
 

--- a/src/server/src/lib.rs
+++ b/src/server/src/lib.rs
@@ -29,7 +29,6 @@ pub use buffer::{ReadBuf, WriteBuf};
 
 #[allow(dead_code)]
 mod cmd;
-use cmd::Command;
 
 #[allow(dead_code)]
 mod frame;

--- a/src/server/src/mio/connection.rs
+++ b/src/server/src/mio/connection.rs
@@ -20,7 +20,7 @@ use mio::{event::Event, net::TcpStream};
 use tracing::trace;
 
 use super::{interrupted, would_block};
-use crate::{Command, Error, ReadBuf, Result, WriteBuf};
+use crate::{cmd, Error, ReadBuf, Result, WriteBuf};
 
 pub struct Connection {
     db: Db,
@@ -72,9 +72,7 @@ impl Connection {
             if bytes_read != 0 {
                 self.read_buf.buf.put_slice(&received_data[..bytes_read]);
                 while let Some(frame) = self.read_buf.parse_frame() {
-                    let cmd = Command::from_frame(frame).unwrap();
-                    let reply = cmd.apply(&self.db).unwrap();
-                    self.write_buf.write_frame(&reply);
+                    self.write_buf.write_frame(&cmd::apply(frame, &self.db));
                 }
             }
 

--- a/src/server/src/uio/connection.rs
+++ b/src/server/src/uio/connection.rs
@@ -20,7 +20,7 @@ use io_uring::{cqueue, opcode, squeue, types};
 use tracing::{error, trace};
 
 use super::{check_io_result, IoDriver, Token};
-use crate::{Command, ReadBuf, Result, WriteBuf};
+use crate::{cmd, ReadBuf, Result, WriteBuf};
 
 pub struct Connection {
     id: u64,
@@ -82,9 +82,7 @@ impl Connection {
 
     fn process(&mut self) {
         while let Some(frame) = self.read_buf.parse_frame() {
-            let cmd = Command::from_frame(frame).unwrap();
-            let reply = cmd.apply(&self.db).unwrap();
-            self.write_buf.write_frame(&reply);
+            self.write_buf.write_frame(&cmd::apply(frame, &self.db));
         }
     }
 


### PR DESCRIPTION
Signed-off-by: tison <wander4096@gmail.com>

```
$ redis-cli -p 21716
127.0.0.1:21716> get k k
(error) ERR wrong number of arguments for 'get' command
127.0.0.1:21716> ping 42
"42"
127.0.0.1:21716> ping 42 43
(error) ERR wrong number of arguments for 'ping' command
127.0.0.1:21716> 
```