### PR TITLE
feat: config from file 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "io-uring",
  "libc",
  "mio",
+ "serde",
  "thiserror",
  "tracing",
 ]
@@ -333,6 +334,20 @@ name = "serde"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "sharded-slab"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "anyhow",
  "clap",
  "engula-server",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -328,6 +329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +408,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/src/bin/Cargo.toml
+++ b/src/bin/Cargo.toml
@@ -12,7 +12,8 @@ description = "A low-latency, high-performance data structure store."
 [dependencies]
 engula-server = { version = "0.3", path = "../server" }
 
-clap = { version = "3.0", features = ["derive"] }
 anyhow = "1.0"
+clap = { version = "3.0", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
+toml = "0.5"

--- a/src/bin/src/argenum.rs
+++ b/src/bin/src/argenum.rs
@@ -12,33 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod argenum;
-mod server;
+///! Adapters for [`clap::ArgEnum`].
 
-use anyhow::Result;
-use clap::Parser;
-
-#[derive(Parser)]
-struct Command {
-    #[clap(subcommand)]
-    subcmd: SubCommand,
+#[derive(clap::ArgEnum, Clone)]
+pub enum DriverMode {
+    Mio,
+    #[cfg(target_os = "linux")]
+    Uio,
 }
 
-impl Command {
-    fn run(self) -> Result<()> {
-        match self.subcmd {
-            SubCommand::Server(cmd) => cmd.run(),
+impl From<DriverMode> for engula_server::DriverMode {
+    fn from(mode: DriverMode) -> Self {
+        match mode {
+            DriverMode::Mio => engula_server::DriverMode::Mio,
+            #[cfg(target_os = "linux")]
+            DriverMode::Uio => engula_server::DriverMode::Uio,
         }
     }
-}
-
-#[derive(Parser)]
-enum SubCommand {
-    Server(server::Command),
-}
-
-fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
-    let cmd: Command = Command::parse();
-    cmd.run()
 }

--- a/src/bin/src/server.rs
+++ b/src/bin/src/server.rs
@@ -78,6 +78,7 @@ impl StartCommand {
 
 const DEFAULT_CONNECTION_TIMEOUT: Option<Duration> = None;
 
+/// Merge configs from args and files, and prefer those from args to those from file.
 fn merge_configs(args: StartCommand, values: Option<Value>) -> Result<Config> {
     let addr = args.addr;
 

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -13,6 +13,7 @@ engula-engine = { version = "0.3", path = "../engine" }
 atoi = "0.3"
 bytes = "1.1"
 mio = { version = "0.8.2", features = ["net", "os-ext"] }
+serde = { version = "1.0.136", features = ["derive"] }
 thiserror = "1.0"
 tracing = "0.1"
 

--- a/src/server/src/config.rs
+++ b/src/server/src/config.rs
@@ -26,3 +26,29 @@ pub struct Config {
     pub driver_mode: DriverMode,
     pub connection_timeout: Option<Duration>,
 }
+
+pub struct ConfigBuilder {
+    pub addr: String,
+    pub driver_mode: DriverMode,
+    pub connection_timeout: Option<Duration>,
+}
+
+impl Default for ConfigBuilder {
+    fn default() -> Self {
+        Self {
+            addr: "127.0.0.1:21716".to_string(),
+            driver_mode: DriverMode::Mio,
+            connection_timeout: None,
+        }
+    }
+}
+
+impl ConfigBuilder {
+    pub fn build(self) -> Config {
+        Config {
+            addr: self.addr,
+            driver_mode: self.driver_mode,
+            connection_timeout: self.connection_timeout,
+        }
+    }
+}

--- a/src/server/src/lib.rs
+++ b/src/server/src/lib.rs
@@ -22,7 +22,7 @@ mod error;
 pub use error::{Error, Result};
 
 mod config;
-pub use config::{Config, DriverMode};
+pub use config::{Config, ConfigBuilder, DriverMode};
 
 mod buffer;
 pub use buffer::{ReadBuf, WriteBuf};


### PR DESCRIPTION
This closes #663.

cc @huachaohuang @w41ter @zojw 

Two design decisions are made here:

1. Configs from args or file can be present together. We prefer those from args to those from file.
2. Thus, we should detect whether a config is passed from args, so the default value of args cannot set. Otherwise we don't know it's configured by default or by users.

Code for parsing the toml file can be refactor if we grow our configs.