### PR TITLE
engine: evict key and save to disk cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,8 @@ dependencies = [
  "hashbrown 0.12.0",
  "monoio",
  "rand",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,7 @@ dependencies = [
  "hashbrown 0.12.0",
  "monoio",
  "rand",
+ "serde",
  "tokio",
  "tracing",
 ]

--- a/src/bin/src/server.rs
+++ b/src/bin/src/server.rs
@@ -86,6 +86,13 @@ fn apply_from_values(config_builder: &mut ConfigBuilder, values: Option<ConfigBu
     if let Some(timeout) = values.timeout {
         config_builder.timeout = Some(timeout);
     }
+    if let Some(root) = values.root {
+        config_builder.root = Some(root);
+    }
+    if let Some(max_memory) = values.max_memory {
+        config_builder.max_memory = Some(max_memory);
+    }
+    config_builder.disk_opts = values.disk_opts;
 }
 
 fn apply_from_args(config_builder: &mut ConfigBuilder, args: StartCommand) {

--- a/src/engine/Cargo.toml
+++ b/src/engine/Cargo.toml
@@ -15,6 +15,7 @@ hashbrown = { git = "https://github.com/w41ter/hashbrown.git", features = [
   "raw",
 ] }
 rand = "0.8.5"
+serde = { version = "1.0.136", features = ["derive"] }
 tracing = "0.1"
 monoio = "0.0.4"
 tokio = { version = "1.17.0", features = ["io-util", "sync"] }

--- a/src/engine/Cargo.toml
+++ b/src/engine/Cargo.toml
@@ -15,4 +15,6 @@ hashbrown = { git = "https://github.com/w41ter/hashbrown.git", features = [
   "raw",
 ] }
 rand = "0.8.5"
+tracing = "0.1"
 monoio = "0.0.4"
+tokio = { version = "1.17.0", features = ["io-util", "sync"] }

--- a/src/engine/src/alloc/mod.rs
+++ b/src/engine/src/alloc/mod.rs
@@ -1,0 +1,45 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+struct Allocator;
+
+#[global_allocator]
+static GLOBAL_ALLOC: Allocator = Allocator;
+
+static ALLOCATED: AtomicUsize = AtomicUsize::new(0);
+
+unsafe impl GlobalAlloc for Allocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ret = System.alloc(layout);
+        if !ret.is_null() {
+            ALLOCATED.fetch_add(layout.size(), Ordering::Relaxed);
+        }
+        ret
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        ALLOCATED.fetch_sub(layout.size(), Ordering::Relaxed);
+    }
+}
+
+/// Return the allocated bytes.
+pub fn allocated() -> usize {
+    ALLOCATED.load(Ordering::Relaxed)
+}

--- a/src/engine/src/db.rs
+++ b/src/engine/src/db.rs
@@ -12,63 +12,102 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+use tracing::trace;
 
 use crate::{
+    diskcache::DiskCache,
+    elements::{array::Array, BoxElement},
     key_space::KeySpace,
-    objects::{BoxObject, ObjectLayout, RawObject},
+    objects::{BoxObject, ObjectLayout, RawObject, RawString},
     stats::DbStats,
 };
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct Db {
     state: Arc<Mutex<DbState>>,
 }
 
+unsafe impl Sync for Db {}
 unsafe impl Send for Db {}
 
-unsafe impl Sync for Db {}
-
-#[derive(Default)]
 struct DbState {
-    lru: u32,
+    lru_clock: u32,
+    num_tick: usize,
+    /// The size of memory used after system initialization.
+    // initial_used: usize,
+    max_memory: usize,
     key_space: KeySpace,
+    disk_cache: DiskCache,
 }
 
 impl Db {
-    pub fn get(&self, key: &[u8]) -> Option<RawObject> {
-        let mut state = self.state.lock().unwrap();
+    pub fn new(max_memory: usize, disk_cache: DiskCache) -> Self {
+        Db {
+            state: Arc::new(Mutex::new(DbState {
+                lru_clock: 0,
+                num_tick: 0,
+                max_memory,
+                // initial_used: crate::alloc::allocated(),
+                key_space: KeySpace::default(),
+                disk_cache,
+            })),
+        }
+    }
+
+    pub async fn get(&self, key: &[u8]) -> Option<RawObject> {
+        let mut state = self.state.lock().await;
         match state.key_space.get(key) {
             Some(mut raw_object) => {
-                unsafe {
-                    let object_meta = raw_object.object_meta_mut();
-                    if object_meta.lru() != state.lru {
-                        object_meta.set_lru(state.lru);
+                let object_meta = raw_object.object_meta_mut();
+                if object_meta.lru() != state.lru_clock {
+                    object_meta.set_lru(state.lru_clock);
+                }
+                if object_meta.is_evicted() {
+                    trace!(key = ?key, "load key from disk cache");
+                    if let Some(value) = state.disk_cache.get(key).await.unwrap() {
+                        let string = raw_object
+                            .data_mut::<RawString>()
+                            .expect("Only support RawString");
+                        let mut element = BoxElement::<Array>::with_capacity(value.len());
+                        element.data_slice_mut().copy_from_slice(&value);
+                        assert!(string.update_value(Some(element)).is_none());
+                        string.meta.clear_evicted();
+                    } else {
+                        // This key has been evicted from disk cache.
+                        state.key_space.remove(key);
+                        return None;
                     }
-                };
+                }
                 Some(raw_object)
             }
             None => None,
         }
     }
 
-    pub fn insert<T>(&self, mut object: BoxObject<T>)
+    pub async fn insert<T>(&self, mut object: BoxObject<T>)
     where
         T: ObjectLayout,
     {
-        let mut state = self.state.lock().unwrap();
+        let mut state = self.state.lock().await;
 
-        object.meta.set_lru(state.lru);
+        debug_assert!(!object.meta.is_evicted());
+        debug_assert!(!object.meta.is_tombstone());
+
+        object.meta.set_lru(state.lru_clock);
+        Self::ensure_memory_hard_limit(&mut *state).await;
         state.key_space.insert(object);
     }
 
-    pub fn remove(&self, key: &[u8]) {
-        let mut state = self.state.lock().unwrap();
+    pub async fn remove(&self, key: &[u8]) {
+        let mut state = self.state.lock().await;
         state.key_space.remove(key);
     }
 
-    pub fn delete_keys<'a, K: IntoIterator<Item = &'a [u8]>>(&self, keys: K) -> u64 {
-        let mut state = self.state.lock().unwrap();
+    pub async fn delete_keys<'a, K: IntoIterator<Item = &'a [u8]>>(&self, keys: K) -> u64 {
+        let mut state = self.state.lock().await;
         let mut num_deleted = 0;
         for key in keys {
             if state.key_space.remove(key) {
@@ -78,14 +117,45 @@ impl Db {
         num_deleted
     }
 
-    pub fn on_tick(&self) {
-        let mut state = self.state.lock().unwrap();
+    pub async fn on_tick(&self) {
+        let mut state = self.state.lock().await;
+        state.num_tick += 1;
+        if state.num_tick % 10 == 0 {
+            state.lru_clock = state.lru_clock.wrapping_add(1);
+        }
         state.key_space.recycle_some_expired_keys();
         state.key_space.try_resize_space();
     }
 
-    pub fn stats(&self) -> DbStats {
-        let state = self.state.lock().unwrap();
+    pub async fn stats(&self) -> DbStats {
+        let state = self.state.lock().await;
         state.key_space.stats()
+    }
+
+    async fn ensure_memory_hard_limit(state: &mut DbState) {
+        loop {
+            let memory_used = crate::alloc::allocated();
+            if memory_used < state.max_memory {
+                return;
+            }
+
+            // try evict some keys to disk.
+            let mut raw_object = match state.key_space.select_random_object() {
+                Some(raw_object) => raw_object,
+                None => break,
+            };
+
+            // TODO(walter) now only support `RawString`.
+            if let Some(string) = raw_object.data_mut::<RawString>() {
+                trace!(key = ?string.key(), "evict key to disk cache");
+                state
+                    .disk_cache
+                    .set(string.key(), string.data_slice())
+                    .await
+                    .unwrap();
+                string.meta.set_evicted();
+                string.update_value(None);
+            }
+        }
     }
 }

--- a/src/engine/src/diskcache/mod.rs
+++ b/src/engine/src/diskcache/mod.rs
@@ -15,11 +15,13 @@
 use std::{io::Result, path::PathBuf};
 
 mod store;
+use serde::Deserialize;
 use store::{BlockHandle, DiskStore};
 
 mod table;
 use table::HashTable;
 
+#[derive(Deserialize, Debug, Clone)]
 pub struct DiskOptions {
     pub mem_capacity: usize,
     pub disk_capacity: usize,

--- a/src/engine/src/diskcache/mod.rs
+++ b/src/engine/src/diskcache/mod.rs
@@ -21,10 +21,10 @@ mod table;
 use table::HashTable;
 
 pub struct DiskOptions {
-    mem_capacity: usize,
-    disk_capacity: usize,
-    file_size: usize,
-    write_buffer_size: usize,
+    pub mem_capacity: usize,
+    pub disk_capacity: usize,
+    pub file_size: usize,
+    pub write_buffer_size: usize,
 }
 
 pub struct DiskCache {

--- a/src/engine/src/key_space.rs
+++ b/src/engine/src/key_space.rs
@@ -292,6 +292,16 @@ impl KeySpace {
         }
     }
 
+    pub fn select_random_object(&mut self) -> Option<RawObject> {
+        let mut raw_objects = self.objects.random_objects(10);
+        raw_objects.sort_unstable_by(compare_raw_objects);
+        if !raw_objects.is_empty() {
+            Some(raw_objects[0])
+        } else {
+            None
+        }
+    }
+
     #[inline]
     pub fn stats(&self) -> DbStats {
         self.stats.clone()
@@ -329,6 +339,10 @@ where
 
 fn equivalent_key(k: &[u8]) -> impl Fn(&ObjectEntry) -> bool + '_ {
     move |x| k.eq(x.raw_object.key())
+}
+
+fn compare_raw_objects(lhs: &RawObject, rhs: &RawObject) -> std::cmp::Ordering {
+    lhs.object_meta().lru().cmp(&rhs.object_meta().lru())
 }
 
 #[cfg(test)]

--- a/src/engine/src/key_space.rs
+++ b/src/engine/src/key_space.rs
@@ -295,11 +295,9 @@ impl KeySpace {
     pub fn select_random_object(&mut self) -> Option<RawObject> {
         let mut raw_objects = self.objects.random_objects(10);
         raw_objects.sort_unstable_by(compare_raw_objects);
-        if !raw_objects.is_empty() {
-            Some(raw_objects[0])
-        } else {
-            None
-        }
+        raw_objects
+            .into_iter()
+            .find(|raw_object| !raw_object.object_meta().is_evicted())
     }
 
     #[inline]

--- a/src/engine/src/lib.rs
+++ b/src/engine/src/lib.rs
@@ -15,8 +15,8 @@
 #![feature(ptr_as_uninit)]
 #![allow(clippy::missing_safety_doc)]
 
+pub mod alloc;
 mod db;
-#[allow(dead_code)]
 mod diskcache;
 pub mod elements;
 mod key_space;
@@ -26,3 +26,4 @@ pub mod stats;
 pub mod time;
 
 pub use db::Db;
+pub use diskcache::{DiskCache, DiskOptions};

--- a/src/engine/src/objects/mod.rs
+++ b/src/engine/src/objects/mod.rs
@@ -81,25 +81,19 @@ impl ObjectMeta {
     pub fn object_type(&self) -> u16 {
         self.meta.user_defined_tag()
     }
+}
 
-    #[inline]
-    pub fn key_len(&self) -> usize {
-        self.meta.key_len() as usize
+impl Deref for ObjectMeta {
+    type Target = RecordMeta;
+
+    fn deref(&self) -> &Self::Target {
+        &self.meta
     }
+}
 
-    #[inline]
-    pub fn set_tombstone(&mut self) {
-        self.meta.set_tombstone();
-    }
-
-    #[inline]
-    pub fn lru(&self) -> u32 {
-        self.meta.lru()
-    }
-
-    #[inline]
-    pub fn set_lru(&mut self, lru: u32) {
-        self.meta.set_lru(lru)
+impl DerefMut for ObjectMeta {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.meta
     }
 }
 
@@ -212,19 +206,12 @@ impl RawObject {
         RawObject { ptr }
     }
 
-    /// # Safety
-    ///
-    /// TODO(walter)
     pub fn object_meta(&self) -> &ObjectMeta {
         unsafe { self.ptr.as_ref() }
     }
 
-    /// # Safety
-    ///
-    /// TODO(walter)
-    #[allow(dead_code)]
-    pub unsafe fn object_meta_mut(&mut self) -> &mut ObjectMeta {
-        self.ptr.as_mut()
+    pub fn object_meta_mut(&mut self) -> &mut ObjectMeta {
+        unsafe { self.ptr.as_mut() }
     }
 
     /// # Safety

--- a/src/engine/src/record.rs
+++ b/src/engine/src/record.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub const RECORD_ELEMENT: u16 = 0b00;
-pub const RECORD_OBJECT: u16 = 0b10;
-const RECORD_USED_MASK: u16 = 0b01;
-const RECORD_TYPE_MASK: u16 = 0b10;
-const RECORD_TOMBSTOME: u16 = 0b100;
+pub const RECORD_ELEMENT: u16 = 0b0000;
+pub const RECORD_OBJECT: u16 = 0b0010;
+const RECORD_USED_MASK: u16 = 0b0001;
+const RECORD_TYPE_MASK: u16 = 0b0010;
+const RECORD_TOMBSTONE: u16 = 0b0100;
+const RECORD_EVICTED: u16 = 0b1000;
 const RECORD_META_SHIFT: u32 = 4;
 
 pub trait RecordType {
@@ -32,7 +33,8 @@ pub struct RecordMeta {
     /// - 0: is this memory used?
     /// - 1: object or element
     /// - 2: tombstone?
-    /// - 3-15: object or element defined
+    /// - 3: evicted?
+    /// - 4-15: object or element defined
     tag: u16,
     left: [u8; 6],
 }
@@ -93,15 +95,27 @@ impl RecordMeta {
     }
 
     pub fn is_tombstone(self) -> bool {
-        self.tag & RECORD_TOMBSTOME != 0
+        self.tag & RECORD_TOMBSTONE != 0
     }
 
     pub fn set_tombstone(&mut self) {
-        self.tag |= RECORD_TOMBSTOME;
+        self.tag |= RECORD_TOMBSTONE;
     }
 
     pub fn clear_tombstone(&mut self) {
-        self.tag &= !RECORD_TOMBSTOME;
+        self.tag &= !RECORD_TOMBSTONE;
+    }
+
+    pub fn is_evicted(self) -> bool {
+        self.tag & RECORD_EVICTED != 0
+    }
+
+    pub fn set_evicted(&mut self) {
+        self.tag |= RECORD_EVICTED;
+    }
+
+    pub fn clear_evicted(&mut self) {
+        self.tag &= !RECORD_EVICTED;
     }
 
     pub fn tag(&self) -> u16 {

--- a/src/server/src/cmd/cmd_des.rs
+++ b/src/server/src/cmd/cmd_des.rs
@@ -62,7 +62,7 @@ impl CommandDescs {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 pub trait CommandAction {
     async fn apply(&self, db: &Db) -> crate::Result<Frame>;
     fn get_name(&self) -> &str;

--- a/src/server/src/cmd/command.rs
+++ b/src/server/src/cmd/command.rs
@@ -33,7 +33,7 @@ pub(crate) fn parse_command(
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl CommandAction for Command {
     async fn apply(&self, _: &Db) -> crate::Result<Frame> {
         let mut cmds = Vec::new();
@@ -66,7 +66,7 @@ pub(crate) fn parse_command_info(
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl CommandAction for CommandInfo {
     async fn apply(&self, _: &Db) -> crate::Result<Frame> {
         let mut cmds = Vec::new();

--- a/src/server/src/cmd/del.rs
+++ b/src/server/src/cmd/del.rs
@@ -50,12 +50,14 @@ impl Del {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl CommandAction for Del {
     async fn apply(&self, db: &Db) -> crate::Result<Frame> {
         // Get the value from the shared database state
-        let response =
-            Frame::Integer(db.delete_keys(self.keys.iter().map(|bytes| bytes.as_ref())) as i64);
+        let response = Frame::Integer(
+            db.delete_keys(self.keys.iter().map(|bytes| bytes.as_ref()))
+                .await as i64,
+        );
 
         debug!(?response);
 

--- a/src/server/src/cmd/get.rs
+++ b/src/server/src/cmd/get.rs
@@ -72,7 +72,7 @@ pub(crate) fn parse_frames(
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl CommandAction for Get {
     /// Apply the `Get` command to the specified `Db` instance.
     ///
@@ -80,7 +80,7 @@ impl CommandAction for Get {
     /// to execute a received command.
     async fn apply(&self, db: &Db) -> crate::Result<Frame> {
         // Get the value from the shared database state
-        let response = if let Some(object_ref) = db.get(&self.key) {
+        let response = if let Some(object_ref) = db.get(&self.key).await {
             if let Some(value) = object_ref.data::<RawString>() {
                 // If a value is present, it is written to the client in "bulk"
                 // format.

--- a/src/server/src/cmd/info.rs
+++ b/src/server/src/cmd/info.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+use engula_engine::alloc::allocated;
 use tracing::debug;
 
 use super::*;
@@ -64,7 +65,9 @@ impl CommandAction for Info {
     async fn apply(&self, db: &Db) -> crate::Result<Frame> {
         let db_stats = db.stats().await;
         let content = format!(
-            r#"# Stats
+            r#"# Memory
+used_memory:{used_memory}
+# Stats
 evicted_keys:{evicted_keys}
 expired_keys:{expired_keys}
 keyspace_hits:{keyspace_hits}
@@ -72,6 +75,7 @@ keyspace_misses:{keyspace_misses}
 # Keyspace
 keys:{num_keys}
 "#,
+            used_memory = allocated(),
             evicted_keys = db_stats.evicted_keys,
             expired_keys = db_stats.expired_keys,
             keyspace_hits = db_stats.keyspace_hits,

--- a/src/server/src/cmd/info.rs
+++ b/src/server/src/cmd/info.rs
@@ -58,11 +58,11 @@ pub(crate) fn parse_frames(
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl CommandAction for Info {
     /// Apply the `INFO` command and return the message.
     async fn apply(&self, db: &Db) -> crate::Result<Frame> {
-        let db_stats = db.stats();
+        let db_stats = db.stats().await;
         let content = format!(
             r#"# Stats
 evicted_keys:{evicted_keys}

--- a/src/server/src/cmd/ping.rs
+++ b/src/server/src/cmd/ping.rs
@@ -71,7 +71,7 @@ pub(crate) fn parse_frames(
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl CommandAction for Ping {
     /// Apply the `Ping` command and return the message.
     ///

--- a/src/server/src/cmd/unknown.rs
+++ b/src/server/src/cmd/unknown.rs
@@ -33,7 +33,7 @@ impl Unknown {
     }
 }
 
-#[async_trait]
+#[async_trait(?Send)]
 impl CommandAction for Unknown {
     /// Responds to the client, indicating the command is not recognized.
     ///

--- a/src/server/src/config.rs
+++ b/src/server/src/config.rs
@@ -14,18 +14,25 @@
 
 use std::time::Duration;
 
+use engula_engine::DiskOptions;
 use serde::Deserialize;
 
 #[derive(Debug)]
 pub struct Config {
     pub addr: String,
     pub connection_timeout: Option<Duration>,
+    pub max_memory: usize,
+    pub root: String,
+    pub disk_opts: DiskOptions,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct ConfigBuilder {
     pub addr: Option<String>,
     pub timeout: Option<u64>,
+    pub max_memory: Option<usize>,
+    pub root: Option<String>,
+    pub disk_opts: DiskOptions,
 }
 
 impl Default for ConfigBuilder {
@@ -33,6 +40,14 @@ impl Default for ConfigBuilder {
         Self {
             addr: Some("127.0.0.1:21716".to_string()),
             timeout: Some(0),
+            max_memory: Some(0),
+            root: None,
+            disk_opts: DiskOptions {
+                mem_capacity: 128 * 1024 * 1204,
+                file_size: 32 * 1024 * 1024,
+                disk_capacity: 1024 * 1024 * 1024,
+                write_buffer_size: 64 * 1024 * 1024,
+            },
         }
     }
 }
@@ -45,6 +60,9 @@ impl ConfigBuilder {
                 0 => None,
                 timeout => Some(Duration::from_secs(timeout)),
             }),
+            max_memory: self.max_memory.expect("max memory is required"),
+            root: self.root.expect("path of engine root is required"),
+            disk_opts: self.disk_opts,
         }
     }
 }

--- a/src/server/src/server.rs
+++ b/src/server/src/server.rs
@@ -411,7 +411,7 @@ impl Server {
     }
 
     async fn on_db_tick(db: Db) {
-        db.on_tick();
+        db.on_tick().await;
     }
 }
 


### PR DESCRIPTION
Example of `config.toml`:

```toml
max_memory=134217728
root="/tmp/disk-cache"

[disk_opts]
mem_capacity=134217728
file_size=33554432
disk_capacity=1073741824
write_buffer_size=67108864
```
