### PR TITLE
api: add structured error message

### DIFF
--- a/src/api/engula/server/v1/error.proto
+++ b/src/api/engula/server/v1/error.proto
@@ -1,0 +1,61 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package engula.server.v1;
+
+import "engula/server/v1/metadata.proto";
+
+/// A structured error for passing detailed error information over RPC. It
+/// is usually used with 'grpc-status-details-bin'.
+///
+/// NOTES: The user needs to ensure that if there is an error, then details
+/// must not be empty.
+message Error {
+    repeated ErrorDetail details = 1;
+}
+
+message ErrorDetail {
+    string message = 1;
+
+    ErrorDetailUnion detail = 2;
+}
+
+message ErrorDetailUnion {
+    oneof value {
+        NotLeader not_leader = 1;
+        NotMatch not_match = 2;
+        ServerIsBusy server_is_busy = 3;
+        GroupNotFound group_not_found = 4;
+        int32 status_code = 5;
+    }
+}
+
+message NotLeader {
+    uint64 group_id = 1;
+    /// The leader of the requested group.
+    ReplicaDesc leader = 2;
+}
+
+message NotMatch {
+    uint64 group_id = 1;
+    uint64 shard_id = 2;
+}
+
+message ServerIsBusy {}
+
+message GroupNotFound {
+    uint64 group_id = 1;
+}

--- a/src/api/engula/server/v1/node.proto
+++ b/src/api/engula/server/v1/node.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package engula.server.v1;
 
 import "engula/v1/engula.proto";
+import "engula/server/v1/error.proto";
 import "engula/server/v1/metadata.proto";
 
 service Node {
@@ -42,7 +43,7 @@ message GroupResponse {
     GroupResponseUnion response = 1;
 
     /// Only used in BatchResponse.
-    Status status = 2;
+    Error error = 2;
 }
 
 message GroupRequestUnion {
@@ -75,11 +76,6 @@ message CreateReplicaRequest {
 }
 
 message CreateReplicaResponse {}
-
-message Status {
-  int32 code = 1;
-  string message = 2;
-}
 
 message CreateShardRequest {
   ShardDesc shard = 1;

--- a/src/api/src/lib.rs
+++ b/src/api/src/lib.rs
@@ -19,5 +19,122 @@ pub mod v1 {
 pub mod server {
     pub mod v1 {
         tonic::include_proto!("engula.server.v1");
+
+        impl GroupResponse {
+            #[inline]
+            pub fn new(response: group_response_union::Response) -> Self {
+                GroupResponse {
+                    response: Some(GroupResponseUnion {
+                        response: Some(response),
+                    }),
+                    error: None,
+                }
+            }
+
+            #[inline]
+            pub fn with_error(resp: group_response_union::Response, error: Error) -> Self {
+                GroupResponse {
+                    response: Some(GroupResponseUnion {
+                        response: Some(resp),
+                    }),
+                    error: Some(error),
+                }
+            }
+
+            #[inline]
+            pub fn error(error: Error) -> Self {
+                GroupResponse {
+                    response: None,
+                    error: Some(error),
+                }
+            }
+        }
+
+        impl ErrorDetail {
+            #[inline]
+            pub fn new(value: error_detail_union::Value) -> Self {
+                ErrorDetail {
+                    detail: Some(ErrorDetailUnion { value: Some(value) }),
+                    ..Default::default()
+                }
+            }
+
+            #[inline]
+            pub fn with_message(value: error_detail_union::Value, message: String) -> Self {
+                ErrorDetail {
+                    detail: Some(ErrorDetailUnion { value: Some(value) }),
+                    message,
+                }
+            }
+
+            #[inline]
+            pub fn not_leader(value: NotLeader) -> Self {
+                Self::new(error_detail_union::Value::NotLeader(value))
+            }
+
+            #[inline]
+            pub fn server_is_busy(value: ServerIsBusy) -> Self {
+                Self::new(error_detail_union::Value::ServerIsBusy(value))
+            }
+
+            #[inline]
+            pub fn not_match(value: NotMatch) -> Self {
+                Self::new(error_detail_union::Value::NotMatch(value))
+            }
+
+            #[inline]
+            pub fn group_not_found(value: GroupNotFound) -> Self {
+                Self::new(error_detail_union::Value::GroupNotFound(value))
+            }
+
+            #[inline]
+            pub fn status(code: i32, msg: impl Into<String>) -> Self {
+                Self::with_message(error_detail_union::Value::StatusCode(code), msg.into())
+            }
+        }
+
+        impl Error {
+            #[inline]
+            pub fn not_leader(group_id: u64, leader: Option<ReplicaDesc>) -> Self {
+                Self::with_detail_value(error_detail_union::Value::NotLeader(NotLeader {
+                    group_id,
+                    leader,
+                }))
+            }
+
+            #[inline]
+            pub fn server_is_busy() -> Self {
+                Self::with_detail_value(error_detail_union::Value::ServerIsBusy(ServerIsBusy {}))
+            }
+
+            #[inline]
+            pub fn not_match(group_id: u64, shard_id: u64) -> Self {
+                Self::with_detail_value(error_detail_union::Value::NotMatch(NotMatch {
+                    group_id,
+                    shard_id,
+                }))
+            }
+
+            #[inline]
+            pub fn group_not_found(group_id: u64) -> Self {
+                Self::with_detail_value(error_detail_union::Value::GroupNotFound(GroupNotFound {
+                    group_id,
+                }))
+            }
+
+            #[inline]
+            pub fn status(code: i32, msg: impl Into<String>) -> Self {
+                Error {
+                    details: vec![ErrorDetail::status(code, msg)],
+                }
+            }
+
+            #[inline]
+            pub fn with_detail_value(value: error_detail_union::Value) -> Self {
+                Error {
+                    details: vec![ErrorDetail::new(value)],
+                }
+            }
+        }
     }
 }

--- a/src/server/src/bootstrap.rs
+++ b/src/server/src/bootstrap.rs
@@ -147,7 +147,9 @@ async fn try_join_cluster(
         .collect::<Vec<_>>();
 
     if join_list.is_empty() {
-        return Err(Error::InvalidArgument("the filtered join list is empty".into()));
+        return Err(Error::InvalidArgument(
+            "the filtered join list is empty".into(),
+        ));
     }
 
     let mut backoff: u64 = 1;

--- a/src/server/src/bootstrap.rs
+++ b/src/server/src/bootstrap.rs
@@ -147,7 +147,7 @@ async fn try_join_cluster(
         .collect::<Vec<_>>();
 
     if join_list.is_empty() {
-        return Err(Error::Invalid("the filtered join list is empty".into()));
+        return Err(Error::InvalidArgument("the filtered join list is empty".into()));
     }
 
     let mut backoff: u64 = 1;


### PR DESCRIPTION
This PR closes #707.

I added a structured error message for transporting detailed errors in RPC.

There are two ways to use it:
1. Combine with `grpc-status-details-bin`, for example, use `tonic::Status::with_details` to build, set the code to `Code::Unknown`, so that the client can extract detail from it and deserialize it as `Error`.
2. Add an `Error` field to `GroupResponse`, so that `BatchResponse` is always successful, and each `GroupResponse` can have separate error message; at the same time, even if a group request is successfully executed, `Error` message can also be carried in `GroupResponse`, such as follower read request returns the `ReplicaDesc` of the leader.

