### PR TITLE
client: add node_client 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ name = "engula-client"
 version = "0.4.0"
 dependencies = [
  "engula-api",
+ "tonic",
 ]
 
 [[package]]

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -9,3 +9,4 @@ description = "The Engula API."
 
 [dependencies]
 engula-api = { version = "0.4", path = "../api" }
+tonic = "0.7.2"

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -13,3 +13,5 @@
 // limitations under the License.
 
 mod node_client;
+
+pub use node_client::Client as NodeClient;

--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -12,11 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
-}
+mod node_client;

--- a/src/client/src/node_client.rs
+++ b/src/client/src/node_client.rs
@@ -34,17 +34,30 @@ impl Client {
         Ok(res.into_inner().addrs)
     }
 
+    // NOTE: This method is always called by the root group.
     pub async fn create_replica(
         &self,
         replica_id: u64,
-        group: GroupDesc,
+        group_desc: GroupDesc,
     ) -> Result<(), tonic::Status> {
         let mut client = self.client.clone();
         let req = CreateReplicaRequest {
             replica_id,
-            group: Some(group),
+            group: Some(group_desc),
         };
         client.create_replica(req).await?;
         Ok(())
+    }
+
+    // NOTE: This method is a low-level interface.
+    pub async fn batch_group_request(
+        &self,
+        node_id: u64,
+        requests: Vec<GroupRequest>,
+    ) -> Result<Vec<GroupResponse>, tonic::Status> {
+        let mut client = self.client.clone();
+        let req = BatchRequest { node_id, requests };
+        let res = client.batch(req).await?;
+        Ok(res.into_inner().responses)
     }
 }

--- a/src/client/src/node_client.rs
+++ b/src/client/src/node_client.rs
@@ -108,6 +108,21 @@ impl RequestBatchBuilder {
         self
     }
 
+    pub fn create_shard(mut self, group_id: u64, shard_desc: ShardDesc) -> Self {
+        self.requests.push(GroupRequest {
+            group_id,
+            shard_id: 0, // create_shard doesn't take this field
+            request: Some(GroupRequestUnion {
+                request: Some(group_request_union::Request::CreateShard(
+                    CreateShardRequest {
+                        shard: Some(shard_desc),
+                    },
+                )),
+            }),
+        });
+        self
+    }
+
     pub fn build(self) -> BatchRequest {
         BatchRequest {
             node_id: self.node_id,

--- a/src/client/src/node_client.rs
+++ b/src/client/src/node_client.rs
@@ -1,0 +1,36 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use engula_api::{server::v1::*, v1::*};
+use tonic::transport::Channel;
+
+#[derive(Debug, Clone)]
+pub struct Client {
+    client: node_client::NodeClient<Channel>,
+}
+
+impl Client {
+    pub async fn connect(addr: String) -> Result<Self, tonic::transport::Error> {
+        let addr = format!("http://{}", addr);
+        let client = node_client::NodeClient::connect(addr).await?;
+        Ok(Self { client })
+    }
+
+    pub async fn get_root(&self) -> Result<Vec<String>, tonic::Status> {
+        let mut client = self.client.clone();
+        let req = GetRootRequest::default();
+        let res = client.get_root(req).await?;
+        Ok(res.into_inner().addrs)
+    }
+}

--- a/src/client/src/node_client.rs
+++ b/src/client/src/node_client.rs
@@ -59,12 +59,14 @@ impl Client {
     }
 }
 
+#[allow(unused)]
 #[derive(Debug, Clone)]
 pub struct RequestBatchBuilder {
     node_id: u64,
     requests: Vec<GroupRequest>,
 }
 
+#[allow(unused)]
 impl RequestBatchBuilder {
     pub fn new(node_id: u64) -> Self {
         Self {

--- a/src/client/src/node_client.rs
+++ b/src/client/src/node_client.rs
@@ -33,4 +33,18 @@ impl Client {
         let res = client.get_root(req).await?;
         Ok(res.into_inner().addrs)
     }
+
+    pub async fn create_replica(
+        &self,
+        replica_id: u64,
+        group: GroupDesc,
+    ) -> Result<(), tonic::Status> {
+        let mut client = self.client.clone();
+        let req = CreateReplicaRequest {
+            replica_id,
+            group: Some(group),
+        };
+        client.create_replica(req).await?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
This refers to #710.

This patch brings a basic implementation of `node_client`.

~~There is an open question about whether we should use a dedicated method for create shard (https://github.com/engula/engula/pull/709#discussion_r886779559).~~ Resolved.

Also, I'm unsure how to testing via bootstrap a cluster and fulfill kv pairs yet. @w41ter you may use this patch to write some liveness and get/put tests.