### PR TITLE
node: support get_root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,7 @@ name = "engula-api"
 version = "0.4.0"
 dependencies = [
  "prost",
+ "prost-types",
  "tonic",
  "tonic-build",
 ]

--- a/src/api/Cargo.toml
+++ b/src/api/Cargo.toml
@@ -10,6 +10,7 @@ description = "The Engula API."
 [dependencies]
 tonic = "0.7.2"
 prost = "0.10.3"
+prost-types = "0.10.1"
 
 [build-dependencies]
 tonic-build = "0.7.2"

--- a/src/api/engula/server/v1/error.proto
+++ b/src/api/engula/server/v1/error.proto
@@ -39,7 +39,8 @@ message ErrorDetailUnion {
         NotMatch not_match = 2;
         ServerIsBusy server_is_busy = 3;
         GroupNotFound group_not_found = 4;
-        int32 status_code = 5;
+        NotRoot not_root = 5;
+        int32 status_code = 6;
     }
 }
 
@@ -47,6 +48,10 @@ message NotLeader {
     uint64 group_id = 1;
     /// The leader of the requested group.
     ReplicaDesc leader = 2;
+}
+
+message NotRoot {
+    repeated string root = 1;
 }
 
 message NotMatch {

--- a/src/api/engula/server/v1/node.proto
+++ b/src/api/engula/server/v1/node.proto
@@ -19,11 +19,13 @@ package engula.server.v1;
 import "engula/v1/engula.proto";
 import "engula/server/v1/error.proto";
 import "engula/server/v1/metadata.proto";
+import "google/protobuf/field_mask.proto";
 
 service Node {
   rpc Batch(BatchRequest) returns (BatchResponse) {}
   rpc GetRoot(GetRootRequest) returns (GetRootResponse) {}
   rpc CreateReplica(CreateReplicaRequest) returns (CreateReplicaResponse) {}
+  rpc RootHeartbeat(HeartbeatRequest) returns (HeartbeatResponse) {}
 }
 
 message BatchRequest {
@@ -40,10 +42,10 @@ message GroupRequest {
 }
 
 message GroupResponse {
-    GroupResponseUnion response = 1;
+  GroupResponseUnion response = 1;
 
-    /// Only used in BatchResponse.
-    Error error = 2;
+  /// Only used in BatchResponse.
+  Error error = 2;
 }
 
 message GroupRequestUnion {
@@ -81,21 +83,15 @@ message CreateReplicaRequest {
 
 message CreateReplicaResponse {}
 
-message CreateShardRequest {
-  ShardDesc shard = 1;
-}
+message CreateShardRequest { ShardDesc shard = 1; }
 
 message CreateShardResponse {}
 
-message ChangeReplicasRequest {
-  ChangeReplicas change_replicas = 1;
-}
+message ChangeReplicasRequest { ChangeReplicas change_replicas = 1; }
 
 message ChangeReplicasResponse {}
 
-message ChangeReplicas {
-  repeated ChangeReplica changes = 1;
-}
+message ChangeReplicas { repeated ChangeReplica changes = 1; }
 
 message ChangeReplica {
   ChangeReplicaType change_type = 1;
@@ -109,3 +105,68 @@ enum ChangeReplicaType {
   REMOVE = 1;
   ADD_LEARNER = 2;
 }
+
+message HeartbeatRequest {
+  uint64 timestamp = 1;
+  repeated PiggybackRequest piggybacks = 2;
+}
+
+message HeartbeatResponse {
+  uint64 timestamp = 1;
+  repeated PiggybackResponse piggybacks = 2;
+}
+
+message PiggybackRequest {
+  oneof info {
+    SyncRootRequest sync_root = 1;
+    CollectStatsRequest collect_stats = 2;
+    CollectGroupDetailRequest collect_group_detail = 3;
+  }
+}
+
+message PiggybackResponse {
+  oneof info {
+    SyncRootResponse sync_root = 1;
+    CollectStatsResponse collect_stats = 2;
+    CollectGroupDetailResponse collect_group_detail = 3;
+  }
+}
+
+message SyncRootRequest { repeated NodeDesc roots = 1; }
+
+message SyncRootResponse {}
+
+message CollectStatsRequest { google.protobuf.FieldMask field_mask = 1; }
+
+message CollectStatsResponse {
+  NodeStats node_stats = 1;
+  repeated GroupStats group_stats = 2;
+  repeated ReplicaStats replica_stats = 3;
+}
+
+message NodeStats {
+  uint64 available_space = 1;
+  uint32 group_count = 2;
+  uint32 leader_count = 3;
+  uint64 replica_count = 4;
+  float read_qps = 5;
+  float write_qps = 6;
+}
+
+message GroupStats {
+  uint64 group_id = 1;
+  uint64 shared_count = 2;
+  float read_qps = 3;
+  float write_qps = 4;
+}
+
+message ReplicaStats {
+  uint64 replica_id = 1;
+  uint64 group_id = 2;
+  float read_qps = 3;
+  float write_qps = 4;
+}
+
+message CollectGroupDetailRequest {}
+
+message CollectGroupDetailResponse {}

--- a/src/api/engula/server/v1/root.proto
+++ b/src/api/engula/server/v1/root.proto
@@ -67,8 +67,8 @@ message JoinNodeRequest {
 
 message JoinNodeResponse {
   bytes cluster_id = 1;
-
   uint64 node_id = 2;
+  repeated NodeDesc roots = 3;
 }
 
 message ResolveNodeRequest {

--- a/src/api/src/lib.rs
+++ b/src/api/src/lib.rs
@@ -103,6 +103,11 @@ pub mod server {
             }
 
             #[inline]
+            pub fn not_root_leader(root: Vec<String>) -> Self {
+                Self::with_detail_value(error_detail_union::Value::NotRoot(NotRoot { root }))
+            }
+
+            #[inline]
             pub fn server_is_busy() -> Self {
                 Self::with_detail_value(error_detail_union::Value::ServerIsBusy(ServerIsBusy {}))
             }

--- a/src/client/src/node_client.rs
+++ b/src/client/src/node_client.rs
@@ -57,6 +57,15 @@ impl Client {
         let res = client.batch(req).await?;
         Ok(res.into_inner().responses)
     }
+
+    pub async fn root_heartbeat(
+        &self,
+        req: HeartbeatRequest,
+    ) -> Result<HeartbeatResponse, tonic::Status> {
+        let mut client = self.client.clone();
+        let res = client.root_heartbeat(req).await?;
+        Ok(res.into_inner())
+    }
 }
 
 #[allow(unused)]

--- a/src/server/src/bootstrap.rs
+++ b/src/server/src/bootstrap.rs
@@ -74,7 +74,7 @@ pub fn run(
         let ident = bootstrap_or_join_cluster(&node, &addr, init, join_list).await?;
         node.set_node_ident(&ident).await;
         recover_groups(&node).await?;
-        let mut root = Root::new(executor.clone(), ident.cluster_id, addr.to_owned());
+        let mut root = Root::new(executor.clone(), &ident, addr.to_owned());
         root.bootstrap(&node).await?;
         Ok::<(u64, Root), Error>((ident.node_id, root))
     })?;
@@ -210,7 +210,7 @@ async fn try_join_cluster(
                         resp.node_id,
                     )
                     .await;
-                    node.update_root(resp.roots);
+                    node.update_root(resp.roots).await?;
                     return node_ident;
                 }
                 Err(e) => {

--- a/src/server/src/bootstrap.rs
+++ b/src/server/src/bootstrap.rs
@@ -165,6 +165,7 @@ async fn bootstrap_or_join_cluster(
             "both cluster and node are initialized, node id {}",
             node_ident.node_id
         );
+        node.reload_root_from_engine().await?;
         return Ok(node_ident);
     }
 

--- a/src/server/src/node/mod.rs
+++ b/src/server/src/node/mod.rs
@@ -255,8 +255,7 @@ impl Node {
         self.reload_root_from_engine().await
     }
 
-    #[inline]
-    async fn reload_root_from_engine(&self) -> Result<()> {
+    pub async fn reload_root_from_engine(&self) -> Result<()> {
         let nodes = self
             .state_engine()
             .load_root_nodes()

--- a/src/server/src/node/mod.rs
+++ b/src/server/src/node/mod.rs
@@ -243,7 +243,7 @@ impl Node {
         Ok(Some(()))
     }
 
-    /// Get root that known by node addrs.
+    /// Get root addrs that known by node.
     pub async fn get_root(&self) -> Vec<String> {
         let nodes = self.node_state.lock().await.root.to_owned();
         nodes.iter().map(|n| n.addr.to_owned()).collect()

--- a/src/server/src/node/state_engine.rs
+++ b/src/server/src/node/state_engine.rs
@@ -116,7 +116,7 @@ impl StateEngine {
             .raw_db
             .cf_handle(STATE_CF_NAME)
             .expect("state column family");
-        match self.raw_db.get_pinned_cf(&cf_handle, keys::node_ident())? {
+        match self.raw_db.get_pinned_cf(&cf_handle, keys::root_desc())? {
             Some(value) => {
                 let root_desc = RootDesc::decode(value.as_ref()).expect("valid root desc format");
                 Ok(Some(root_desc.root_nodes))

--- a/src/server/src/root/job.rs
+++ b/src/server/src/root/job.rs
@@ -11,3 +11,53 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+use engula_api::server::v1::{node_client::NodeClient, *};
+
+use super::{Root, Schema};
+use crate::Result;
+
+impl Root {
+    pub async fn send_heartbeat(&self, schema: Schema) -> Result<()> {
+        let cur_node_id = self.current_node_id();
+        let nodes = schema.list_node().await?;
+
+        let mut piggybacks = Vec::new();
+
+        // TODO: no need piggyback root info everytime.
+        if true {
+            let mut roots = schema.get_root_replicas().await?;
+            roots.move_first(cur_node_id);
+            piggybacks.push(PiggybackRequest {
+                info: Some(piggyback_request::Info::SyncRoot(SyncRootRequest {
+                    roots: roots.into(),
+                })),
+            });
+        }
+
+        // TODO: collect stats and group detail.
+
+        for n in nodes {
+            let mut client = NodeClient::connect(n.addr).await?;
+            let res = client
+                .root_heartbeat(HeartbeatRequest {
+                    piggybacks: piggybacks.to_owned(),
+                    timestamp: 0, // TODO: use hlc
+                })
+                .await?;
+
+            for resp in res.into_inner().piggybacks {
+                match resp.info.unwrap() {
+                    piggyback_response::Info::SyncRoot(_) => {}
+                    piggyback_response::Info::CollectStats(_) => {
+                        todo!()
+                    }
+                    piggyback_response::Info::CollectGroupDetail(_) => {
+                        todo!()
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/server/src/root/mod.rs
+++ b/src/server/src/root/mod.rs
@@ -22,7 +22,8 @@ use std::{
     time::Duration,
 };
 
-use self::{schema::Schema, store::RootStore};
+pub use self::schema::Schema;
+use self::store::RootStore;
 use crate::{
     node::{Node, Replica, ReplicaRouteTable},
     runtime::{Executor, TaskPriority},
@@ -72,11 +73,9 @@ impl Root {
         Ok(())
     }
 
-    pub fn schema(&self) -> Result<Arc<Schema>> {
+    pub fn schema(&self) -> Option<Arc<Schema>> {
         let core = self.shared.core.lock().unwrap();
-        core.as_ref()
-            .map(|c| c.schema.clone())
-            .ok_or(Error::NotRootLeader)
+        core.as_ref().map(|c| c.schema.clone())
     }
 
     async fn run(&self, replica_table: ReplicaRouteTable) -> ! {

--- a/src/server/src/root/schema.rs
+++ b/src/server/src/root/schema.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use engula_api::{
     server::v1::{
@@ -139,16 +139,70 @@ impl Schema {
     pub async fn add_node(&self, desc: NodeDesc) -> Result<NodeDesc> {
         let mut desc = desc.to_owned();
         desc.id = self.next_id(META_NODE_ID_KEY).await?;
+        self.batch_put(PutBatchBuilder::default().put_node(desc.to_owned()).build())
+            .await?;
         Ok(desc)
+    }
+
+    pub async fn list_node(&self) -> Result<Vec<NodeDesc>> {
+        let vals = self.list(SYSTEM_NODE_COLLECTION_ID).await?;
+        let mut nodes = Vec::new();
+        for val in vals {
+            nodes
+                .push(NodeDesc::decode(&*val).map_err(|_| Error::InvalidData("node desc".into()))?);
+        }
+        Ok(nodes)
     }
 
     pub async fn get_node(&self, id: u64) -> Result<Option<NodeDesc>> {
         self.get_node_internal(id).await
     }
 
+    pub async fn get_group(&self, id: u64) -> Result<Option<GroupDesc>> {
+        self.get_group_internal(id).await
+    }
+
     pub async fn delete_node(&self, id: u64) -> Result<()> {
         self.delete(SYSTEM_NODE_COLLECTION_ID, &id.to_le_bytes())
             .await
+    }
+
+    pub async fn get_root_replicas(&self) -> Result<ReplicaNodes> {
+        let root_desc = self
+            .get_group(ROOT_GROUP_ID)
+            .await?
+            .ok_or(Error::GroupNotFound(ROOT_GROUP_ID))?;
+        let mut nodes = HashMap::new();
+        for replica in &root_desc.replicas {
+            let node = replica.node_id;
+            if nodes.contains_key(&node) {
+                continue;
+            }
+            let node = self
+                .get_node(node)
+                .await?
+                .ok_or_else(|| Error::InvalidData(format!("node {} data not found", node)))?;
+            nodes.insert(node.id, node);
+        }
+        Ok(ReplicaNodes(nodes.into_iter().map(|(_, v)| v).collect()))
+    }
+}
+
+pub struct ReplicaNodes(Vec<NodeDesc>);
+
+impl From<ReplicaNodes> for Vec<NodeDesc> {
+    fn from(r: ReplicaNodes) -> Self {
+        r.0
+    }
+}
+
+impl ReplicaNodes {
+    pub fn move_first(&mut self, id: u64) {
+        if let Some(idx) = self.0.iter().position(|n| n.id == id) {
+            if idx != 0 {
+                self.0.swap(0, idx)
+            }
+        }
     }
 }
 
@@ -317,6 +371,18 @@ impl Schema {
         Ok(Some(desc))
     }
 
+    async fn get_group_internal(&self, id: u64) -> Result<Option<GroupDesc>> {
+        let val = self
+            .get(SYSTEM_GROUP_COLLECTION_ID, &id.to_le_bytes())
+            .await?;
+        if val.is_none() {
+            return Ok(None);
+        }
+        let desc = GroupDesc::decode(&*val.unwrap())
+            .map_err(|_| Error::InvalidData(format!("group desc: {}", id)))?;
+        Ok(Some(desc))
+    }
+
     async fn get_meta(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
         self.get(SYSTEM_MATE_COLLECTION_ID, key).await
     }
@@ -335,6 +401,12 @@ impl Schema {
 
     async fn delete(&self, collection_id: u64, key: &[u8]) -> Result<()> {
         self.store.delete(&data_key(collection_id, key)).await
+    }
+
+    async fn list(&self, collection_id: u64) -> Result<Vec<Vec<u8>>> {
+        self.store
+            .list(collection_id.to_le_bytes().as_slice())
+            .await
     }
 
     async fn next_id(&self, id_type: &str) -> Result<u64> {

--- a/src/server/src/root/store.rs
+++ b/src/server/src/root/store.rs
@@ -102,4 +102,9 @@ impl RootStore {
             .await?;
         Ok(())
     }
+
+    pub async fn list(&self, _prefix: &[u8]) -> Result<Vec<Vec<u8>>> {
+        // TODO(zojw): impl scan prefix.
+        Ok(vec![])
+    }
 }

--- a/src/server/src/service/node.rs
+++ b/src/server/src/service/node.rs
@@ -60,7 +60,8 @@ impl node_server::Node for Server {
         &self,
         request: Request<GetRootRequest>,
     ) -> Result<Response<GetRootResponse>, Status> {
-        todo!()
+        let addrs = self.node.get_root().await;
+        Ok(Response::new(GetRootResponse { addrs }))
     }
 
     async fn create_replica(
@@ -101,6 +102,7 @@ fn error_to_response(err: Error) -> GroupResponse {
         Error::InvalidArgument(msg) => v1::Error::status(Code::InvalidArgument.into(), msg),
         Error::GroupNotFound(group_id) => v1::Error::group_not_found(group_id),
         Error::NotLeader(group_id, leader) => v1::Error::not_leader(group_id, leader),
+        Error::NotRootLeader(roots) => v1::Error::not_root_leader(roots),
         Error::Transport(inner) => v1::Error::status(Code::Internal.into(), inner.to_string()),
         Error::RocksDb(inner) => v1::Error::status(Code::Internal.into(), inner.to_string()),
         Error::Raft(inner) => v1::Error::status(Code::Internal.into(), inner.to_string()),
@@ -113,7 +115,6 @@ fn error_to_response(err: Error) -> GroupResponse {
             v1::Error::status(Code::Internal.into(), err.to_string())
         }
         err @ Error::InvalidData(_) => v1::Error::status(Code::Internal.into(), err.to_string()),
-        err @ Error::NotRootLeader => v1::Error::status(Code::Internal.into(), err.to_string()),
         err @ Error::ClusterNotMatch => v1::Error::status(Code::Internal.into(), err.to_string()),
         err @ Error::Canceled => v1::Error::status(Code::Cancelled.into(), err.to_string()),
         err @ Error::Rpc(_) => v1::Error::status(Code::Internal.into(), err.to_string()),

--- a/src/server/src/service/root.rs
+++ b/src/server/src/service/root.rs
@@ -69,9 +69,14 @@ impl root_server::Root for Server {
             }
         }
         self.address_resolver.insert(&node);
-        Ok(Response::new(JoinNodeResponse {
+
+        let mut roots = schema.get_root_replicas().await?;
+        roots.move_first(node.id);
+
+        Ok::<Response<JoinNodeResponse>, Status>(Response::new(JoinNodeResponse {
             cluster_id,
             node_id: node.id,
+            roots: roots.into(),
         }))
     }
 


### PR DESCRIPTION
closes #730

Support `get_root` on node service

1. First bootstrap  node, save itself as root node in its state_engine
2. Other join bootstrap node, save join response's  root nodes in state_engine
3. Root leader broadcast root nodes(and first element is current leader) to all known recent nodes periodically
4. Node handles heartbeat and update root info in memory + state_engine
6. Client should call get_node and try first element(high probability as current root leader)
7. Root service method should return NotRoot error with its known root

The node power-off long time and all its known root nodes have dead maybe not work until recieve root hearbeat