### PR TITLE
api,server: remove cluster_id in JoinNodeRequest

### DIFF
--- a/src/api/engula/server/v1/root.proto
+++ b/src/api/engula/server/v1/root.proto
@@ -62,7 +62,6 @@ message WatchResponse {
 
 message JoinNodeRequest {
   string addr = 1;
-  optional bytes cluster_id = 2;
 }
 
 message JoinNodeResponse {

--- a/src/server/src/bootstrap.rs
+++ b/src/server/src/bootstrap.rs
@@ -195,23 +195,13 @@ async fn try_join_cluster(
         ));
     }
 
-    let prev_cluster_id = if let Some(ident) = node.state_engine().read_ident().await? {
-        Some(ident.cluster_id)
-    } else {
-        None
-    };
-
     let mut backoff: u64 = 1;
     loop {
         for addr in &join_list {
-            match issue_join_request(addr, local_addr, prev_cluster_id.to_owned()).await {
+            match issue_join_request(addr, local_addr).await {
                 Ok(resp) => {
-                    let node_ident = save_node_ident(
-                        node.state_engine(),
-                        resp.cluster_id.to_owned(),
-                        resp.node_id,
-                    )
-                    .await;
+                    let node_ident =
+                        save_node_ident(node.state_engine(), resp.cluster_id, resp.node_id).await;
                     node.update_root(resp.roots).await?;
                     return node_ident;
                 }
@@ -225,16 +215,11 @@ async fn try_join_cluster(
     }
 }
 
-async fn issue_join_request(
-    target_addr: &str,
-    local_addr: &str,
-    cluster_id: Option<Vec<u8>>,
-) -> Result<JoinNodeResponse> {
+async fn issue_join_request(target_addr: &str, local_addr: &str) -> Result<JoinNodeResponse> {
     let client = RootClient::connect(target_addr.to_string()).await?;
     let resp = client
         .join_node(JoinNodeRequest {
             addr: local_addr.to_owned(),
-            cluster_id,
         })
         .await?;
     Ok(resp)

--- a/src/server/src/service/root.rs
+++ b/src/server/src/service/root.rs
@@ -63,11 +63,6 @@ impl root_server::Root for Server {
             })
             .await?;
         let cluster_id = schema.cluster_id().await?.unwrap();
-        if let Some(prev_cluster_id) = request.cluster_id {
-            if prev_cluster_id != cluster_id {
-                return Err(Error::ClusterNotMatch.into());
-            }
-        }
         self.address_resolver.insert(&node);
 
         let mut roots = schema.get_root_replicas().await?;


### PR DESCRIPTION
This filed was introduced in #718, it aims to prevent nodes that do not belong to the target cluster from being added to the cluster.

In the previous PRs(https://github.com/engula/engula/pull/731#discussion_r892999362, https://github.com/engula/engula/pull/737#discussion_r893666728), I found that this code does not actually execute, because each Node will only successfully call `join` once, and save the cluster id. Once successful, no subsequent `join` request will be issued.

This field was added to `JoinNodeRequest` by mistake, so I removed it. For its purpose, there should be a separate RPC (or adding a `cluster_id` field on the key RPC requests) to confirm that the cluster id matches.