### PR TITLE
server: report replica state and group descriptor changes

### DIFF
--- a/src/server/src/error.rs
+++ b/src/server/src/error.rs
@@ -63,6 +63,7 @@ pub enum Error {
     #[error("not leader of group {0}")]
     NotLeader(u64, Option<ReplicaDesc>),
 }
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 impl From<Error> for tonic::Status {

--- a/src/server/src/node/job/destory_replica.rs
+++ b/src/server/src/node/job/destory_replica.rs
@@ -25,7 +25,7 @@ use crate::{
 
 /// Clean a group engine and save the replica state to `ReplicaLocalState::Tombstone`.
 pub fn setup(
-    executor: Executor,
+    executor: &Executor,
     group_id: u64,
     replica_id: u64,
     state_engine: StateEngine,

--- a/src/server/src/node/job/mod.rs
+++ b/src/server/src/node/job/mod.rs
@@ -13,5 +13,7 @@
 // limitations under the License.
 
 mod destory_replica;
+mod report_state;
 
 pub use destory_replica::setup as setup_destory_replica;
+pub use report_state::{setup as setup_report_state, StateChannel};

--- a/src/server/src/node/job/report_state.rs
+++ b/src/server/src/node/job/report_state.rs
@@ -1,0 +1,141 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use engula_api::server::v1::{
+    report_request::GroupUpdates, root_client::RootClient, GroupDesc, ReplicaState, ReportRequest,
+};
+use futures::{channel::mpsc, StreamExt};
+use tracing::warn;
+
+use crate::{
+    node::StateEngine,
+    runtime::{Executor, TaskPriority},
+    Error, Result,
+};
+
+#[derive(Clone)]
+pub struct StateChannel {
+    sender: mpsc::UnboundedSender<GroupUpdates>,
+}
+
+pub fn setup(executor: &Executor, state_engine: StateEngine) -> StateChannel {
+    let (sender, receiver) = mpsc::unbounded();
+
+    executor.spawn(None, TaskPriority::IoHigh, async move {
+        report_state_worker(receiver, state_engine).await;
+    });
+
+    StateChannel { sender }
+}
+
+async fn report_state_worker(
+    mut receiver: mpsc::UnboundedReceiver<GroupUpdates>,
+    state_engine: StateEngine,
+) {
+    let mut roots = load_roots(&state_engine).await;
+    while let Some(updates) = wait_state_updates(&mut receiver).await {
+        let req = ReportRequest { updates };
+        report_state_updates(&mut roots, req).await;
+    }
+}
+
+/// Wait until at least a new request is received or the channel is closed. Returns `None` if the
+/// channel is closed.
+async fn wait_state_updates(
+    receiver: &mut mpsc::UnboundedReceiver<GroupUpdates>,
+) -> Option<Vec<GroupUpdates>> {
+    use prost::Message;
+
+    if let Some(update) = receiver.next().await {
+        let mut size = update.encoded_len();
+        let mut updates = vec![update];
+        while size < 32 * 1024 {
+            match receiver.try_next() {
+                Ok(Some(update)) => {
+                    size += update.encoded_len();
+                    updates.push(update);
+                }
+                _ => break,
+            }
+        }
+        return Some(updates);
+    }
+    None
+}
+
+async fn load_roots(state_engine: &StateEngine) -> Vec<String> {
+    loop {
+        if let Some(roots) = state_engine.load_root_nodes().await.unwrap() {
+            return roots.into_iter().map(|d| d.addr).collect();
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+async fn report_state_updates(roots: &mut Vec<String>, request: ReportRequest) {
+    'OUTER: loop {
+        for root in roots.iter() {
+            match issue_report_request(root.to_owned(), &request).await {
+                Ok(()) => return,
+                Err(Error::NotRootLeader(recommends)) => {
+                    *roots = recommends;
+                    continue 'OUTER;
+                }
+                Err(err) => {
+                    warn!("report state updates: {}, root {}", err, root);
+                }
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// Issue report rpc request to root server.
+///
+/// This function is executed synchronously, and it will not affect normal reporting, because
+/// a node has only a small number of replicas, and the replica state changes are not frequent.
+/// Using a synchronous method can simplify the sequence problem introduced by asynchronous
+/// reporting.
+///
+/// If one day you find that reporting has become a bottleneck, you can consider optimizing this
+/// code.
+async fn issue_report_request(addr: String, request: &ReportRequest) -> Result<()> {
+    let mut client = RootClient::connect(addr).await?;
+    client.report(request.clone()).await?;
+    Ok(())
+}
+
+impl StateChannel {
+    #[inline]
+    pub fn broadcast_replica_state(&mut self, group_id: u64, replica_state: ReplicaState) {
+        let update = GroupUpdates {
+            group_id,
+            group_desc: None,
+            replica_state: Some(replica_state),
+        };
+        self.sender.start_send(update).unwrap_or_default();
+    }
+
+    #[inline]
+    pub fn broadcast_group_descriptor(&mut self, group_id: u64, group_desc: GroupDesc) {
+        let update = GroupUpdates {
+            group_id,
+            group_desc: Some(group_desc),
+            replica_state: None,
+        };
+        self.sender.start_send(update).unwrap_or_default();
+    }
+}

--- a/src/server/src/service/root.rs
+++ b/src/server/src/service/root.rs
@@ -53,22 +53,17 @@ impl root_server::Root for Server {
         request: Request<JoinNodeRequest>,
     ) -> std::result::Result<Response<JoinNodeResponse>, Status> {
         let request = request.into_inner();
-        tracing::info!("receive join request");
         let schema = self.schema().await?;
-        tracing::info!("after fetch schema");
         let node = schema
             .add_node(NodeDesc {
                 addr: request.addr,
                 ..Default::default()
             })
             .await?;
-        tracing::info!("after add node");
         let cluster_id = schema.cluster_id().await?.unwrap();
-        tracing::info!("after get cluster id");
         self.address_resolver.insert(&node);
 
         let mut roots = schema.get_root_replicas().await?;
-        tracing::info!("after get root replicas");
         roots.move_first(node.id);
 
         Ok::<Response<JoinNodeResponse>, Status>(Response::new(JoinNodeResponse {


### PR DESCRIPTION
This PR closes #744.

This PR uses `StateObserver` and `DescObserver` to subscribe to `ReplicaState` and `GroupDesc` changes from raft and fsm respectively. Also added `StateChannel` for broadcasting these changes. 

A worker is added to listen to the `StateChannel` and sends these changes to the root servers.