### PR TITLE
api,client,server: support batch writes across shards within a group

### DIFF
--- a/src/api/engula/server/v1/node.proto
+++ b/src/api/engula/server/v1/node.proto
@@ -43,7 +43,6 @@ message BatchResponse { repeated GroupResponse responses = 1; }
 
 message GroupRequest {
   uint64 group_id = 1;
-  uint64 shard_id = 2;
   GroupRequestUnion request = 3;
 }
 
@@ -56,9 +55,9 @@ message GroupResponse {
 
 message GroupRequestUnion {
   oneof request {
-    engula.v1.GetRequest get = 1;
-    engula.v1.PutRequest put = 2;
-    engula.v1.DeleteRequest delete = 3;
+    ShardGetRequest get = 1;
+    ShardPutRequest put = 2;
+    ShardDeleteRequest delete = 3;
     BatchWriteRequest batch_write = 4;
 
     /// Add a new shard to an existing group.
@@ -85,11 +84,26 @@ message GroupResponseUnion {
 /// Since the interface does not need to be exposed to users, the definition is placed in
 /// this file.
 message BatchWriteRequest {
-  repeated engula.v1.DeleteRequest deletes = 1;
-  repeated engula.v1.PutRequest puts = 2;
+  repeated ShardDeleteRequest deletes = 1;
+  repeated ShardPutRequest puts = 2;
 }
 
 message BatchWriteResponse {}
+
+message ShardPutRequest {
+    uint64 shard_id = 1;
+    engula.v1.PutRequest put = 2;
+}
+
+message ShardDeleteRequest {
+    uint64 shard_id = 1;
+    engula.v1.DeleteRequest delete = 2;
+}
+
+message ShardGetRequest {
+    uint64 shard_id = 1;
+    engula.v1.GetRequest get = 2;
+}
 
 message GetRootRequest {}
 

--- a/src/client/src/node_client.rs
+++ b/src/client/src/node_client.rs
@@ -87,9 +87,11 @@ impl RequestBatchBuilder {
     pub fn get(mut self, group_id: u64, shard_id: u64, key: Vec<u8>) -> Self {
         self.requests.push(GroupRequest {
             group_id,
-            shard_id,
             request: Some(GroupRequestUnion {
-                request: Some(group_request_union::Request::Get(GetRequest { key })),
+                request: Some(group_request_union::Request::Get(ShardGetRequest {
+                    shard_id,
+                    get: Some(GetRequest { key }),
+                })),
             }),
         });
         self
@@ -98,9 +100,11 @@ impl RequestBatchBuilder {
     pub fn put(mut self, group_id: u64, shard_id: u64, key: Vec<u8>, value: Vec<u8>) -> Self {
         self.requests.push(GroupRequest {
             group_id,
-            shard_id,
             request: Some(GroupRequestUnion {
-                request: Some(group_request_union::Request::Put(PutRequest { key, value })),
+                request: Some(group_request_union::Request::Put(ShardPutRequest {
+                    shard_id,
+                    put: Some(PutRequest { key, value }),
+                })),
             }),
         });
         self
@@ -109,9 +113,11 @@ impl RequestBatchBuilder {
     pub fn delete(mut self, group_id: u64, shard_id: u64, key: Vec<u8>) -> Self {
         self.requests.push(GroupRequest {
             group_id,
-            shard_id,
             request: Some(GroupRequestUnion {
-                request: Some(group_request_union::Request::Delete(DeleteRequest { key })),
+                request: Some(group_request_union::Request::Delete(ShardDeleteRequest {
+                    shard_id,
+                    delete: Some(DeleteRequest { key }),
+                })),
             }),
         });
         self
@@ -120,7 +126,6 @@ impl RequestBatchBuilder {
     pub fn create_shard(mut self, group_id: u64, shard_desc: ShardDesc) -> Self {
         self.requests.push(GroupRequest {
             group_id,
-            shard_id: 0, // create_shard doesn't take this field
             request: Some(GroupRequestUnion {
                 request: Some(group_request_union::Request::CreateShard(
                     CreateShardRequest {
@@ -145,7 +150,6 @@ impl RequestBatchBuilder {
 
         self.requests.push(GroupRequest {
             group_id,
-            shard_id: 0, // add_replica doesn't take this field.
             request: Some(GroupRequestUnion {
                 request: Some(group_request_union::Request::ChangeReplicas(
                     change_replicas,

--- a/src/server/src/node/replica/eval/cmd_delete.rs
+++ b/src/server/src/node/replica/eval/cmd_delete.rs
@@ -1,3 +1,5 @@
+use engula_api::server::v1::ShardDeleteRequest;
+
 // Copyright 2022 The Engula Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,12 +16,17 @@
 use crate::{
     node::group_engine::{GroupEngine, WriteBatch},
     serverpb::v1::{EvalResult, WriteBatchRep},
-    Result,
+    Error, Result,
 };
 
-pub async fn delete(group_engine: &GroupEngine, shard_id: u64, key: &[u8]) -> Result<EvalResult> {
+pub async fn delete(group_engine: &GroupEngine, req: &ShardDeleteRequest) -> Result<EvalResult> {
+    let delete = req
+        .delete
+        .as_ref()
+        .ok_or_else(|| Error::InvalidArgument("ShardDeleteRequest::delete is None".into()))?;
+
     let mut wb = WriteBatch::default();
-    group_engine.delete(&mut wb, shard_id, key)?;
+    group_engine.delete(&mut wb, req.shard_id, &delete.key)?;
     Ok(EvalResult {
         batch: Some(WriteBatchRep {
             data: wb.data().to_owned(),

--- a/src/server/src/node/replica/eval/cmd_get.rs
+++ b/src/server/src/node/replica/eval/cmd_get.rs
@@ -12,9 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{node::group_engine::GroupEngine, Result};
+use engula_api::server::v1::ShardGetRequest;
+
+use crate::{node::group_engine::GroupEngine, Error, Result};
 
 /// Get the value of the specified key.
-pub async fn get(engine: &GroupEngine, shard_id: u64, key: &[u8]) -> Result<Option<Vec<u8>>> {
-    engine.get(shard_id, key).await
+pub async fn get(engine: &GroupEngine, req: &ShardGetRequest) -> Result<Option<Vec<u8>>> {
+    let get = req
+        .get
+        .as_ref()
+        .ok_or_else(|| Error::InvalidArgument("ShardGetRequest::get is None".into()))?;
+    engine.get(req.shard_id, &get.key).await
 }

--- a/src/server/src/node/replica/eval/cmd_put.rs
+++ b/src/server/src/node/replica/eval/cmd_put.rs
@@ -12,20 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use engula_api::server::v1::ShardPutRequest;
+
 use crate::{
     node::group_engine::{GroupEngine, WriteBatch},
     serverpb::v1::{EvalResult, WriteBatchRep},
-    Result,
+    Error, Result,
 };
 
-pub async fn put(
-    group_engine: &GroupEngine,
-    shard_id: u64,
-    key: &[u8],
-    value: &[u8],
-) -> Result<EvalResult> {
+pub async fn put(group_engine: &GroupEngine, req: &ShardPutRequest) -> Result<EvalResult> {
+    let put = req
+        .put
+        .as_ref()
+        .ok_or_else(|| Error::InvalidArgument("ShardPutRequest::put is None".into()))?;
+
     let mut wb = WriteBatch::default();
-    group_engine.put(&mut wb, shard_id, key, value)?;
+    group_engine.put(&mut wb, req.shard_id, &put.key, &put.value)?;
     Ok(EvalResult {
         batch: Some(WriteBatchRep {
             data: wb.data().to_owned(),

--- a/src/server/src/root/schema.rs
+++ b/src/server/src/root/schema.rs
@@ -622,7 +622,10 @@ impl PutBatchBuilder {
             .batch
             .iter()
             .cloned()
-            .map(|(key, value)| PutRequest { key, value })
+            .map(|(key, value)| ShardPutRequest {
+                shard_id: ROOT_SHARD_ID,
+                put: Some(PutRequest { key, value }),
+            })
             .collect::<Vec<_>>();
         BatchWriteRequest {
             puts,

--- a/src/server/src/root/store.rs
+++ b/src/server/src/root/store.rs
@@ -42,7 +42,6 @@ impl RootStore {
         self.replica
             .execute(&GroupRequest {
                 group_id,
-                shard_id: 0,
                 request: Some(GroupRequestUnion {
                     request: Some(CreateShard(CreateShardRequest { shard: Some(shard) })),
                 }),
@@ -60,7 +59,6 @@ impl RootStore {
         self.replica
             .execute(&GroupRequest {
                 group_id: ROOT_GROUP_ID,
-                shard_id: ROOT_SHARD_ID,
                 request: Some(GroupRequestUnion {
                     request: Some(BatchWrite(batch)),
                 }),
@@ -73,9 +71,11 @@ impl RootStore {
         self.replica
             .execute(&GroupRequest {
                 group_id: ROOT_GROUP_ID,
-                shard_id: ROOT_SHARD_ID,
                 request: Some(GroupRequestUnion {
-                    request: Some(Put(PutRequest { key, value })),
+                    request: Some(Put(ShardPutRequest {
+                        shard_id: ROOT_SHARD_ID,
+                        put: Some(PutRequest { key, value }),
+                    })),
                 }),
             })
             .await?;
@@ -87,10 +87,12 @@ impl RootStore {
             .replica
             .execute(&GroupRequest {
                 group_id: ROOT_GROUP_ID,
-                shard_id: ROOT_SHARD_ID,
                 request: Some(GroupRequestUnion {
-                    request: Some(Get(GetRequest {
-                        key: key.to_owned(),
+                    request: Some(Get(ShardGetRequest {
+                        shard_id: ROOT_SHARD_ID,
+                        get: Some(GetRequest {
+                            key: key.to_owned(),
+                        }),
                     })),
                 }),
             })
@@ -111,10 +113,12 @@ impl RootStore {
         self.replica
             .execute(&GroupRequest {
                 group_id: ROOT_GROUP_ID,
-                shard_id: ROOT_SHARD_ID,
                 request: Some(GroupRequestUnion {
-                    request: Some(Delete(DeleteRequest {
-                        key: key.to_owned(),
+                    request: Some(Delete(ShardDeleteRequest {
+                        shard_id: ROOT_SHARD_ID,
+                        delete: Some(DeleteRequest {
+                            key: key.to_owned(),
+                        }),
                     })),
                 }),
             })


### PR DESCRIPTION
This PR closes #750.

This PR removes the `shard_id` field in `GroupRequest` and adds `Shard{Get,Put,Delete}Request`, so `BatchWriteRequest` can support `put` and `delete` of different shards.

FYI @zojw 