### PR TITLE
root: save system db as "one shard per collection" & support list system collection

### DIFF
--- a/src/api/engula/server/v1/node.proto
+++ b/src/api/engula/server/v1/node.proto
@@ -26,10 +26,11 @@ service Node {
   rpc GetRoot(GetRootRequest) returns (GetRootResponse) {}
   rpc CreateReplica(CreateReplicaRequest) returns (CreateReplicaResponse) {}
 
-  /// RemoveReplica allows shuts down and deletes an orphan replica from the specified node.
+  /// RemoveReplica allows shuts down and deletes an orphan replica from the
+  /// specified node.
   ///
-  /// It is only executed when the user specifies a newer `GroupDesc` and the replica no longer
-  /// belongs to the group.
+  /// It is only executed when the user specifies a newer `GroupDesc` and the
+  /// replica no longer belongs to the group.
   rpc RemoveReplica(RemoveReplicaRequest) returns (RemoveReplicaResponse) {}
   rpc RootHeartbeat(HeartbeatRequest) returns (HeartbeatResponse) {}
 }
@@ -59,13 +60,14 @@ message GroupRequestUnion {
     ShardGetRequest get = 1;
     ShardPutRequest put = 2;
     ShardDeleteRequest delete = 3;
-    BatchWriteRequest batch_write = 4;
+    ShardPrefixListRequest prefix_list = 4;
+    BatchWriteRequest batch_write = 5;
 
     /// Add a new shard to an existing group.
-    CreateShardRequest create_shard = 5;
+    CreateShardRequest create_shard = 6;
 
     /// Change replicas of an existing group.
-    ChangeReplicasRequest change_replicas = 6;
+    ChangeReplicasRequest change_replicas = 7;
   }
 }
 
@@ -74,16 +76,17 @@ message GroupResponseUnion {
     engula.v1.GetResponse get = 1;
     engula.v1.PutResponse put = 2;
     engula.v1.DeleteResponse delete = 3;
-    BatchWriteResponse batch_write = 4;
-    CreateShardResponse create_shard = 5;
-    ChangeReplicasResponse change_replicas = 6;
+    ShardPrefixListResponse preifx_list = 4;
+    BatchWriteResponse batch_write = 5;
+    CreateShardResponse create_shard = 6;
+    ChangeReplicasResponse change_replicas = 7;
   }
 }
 
 /// Execute batch write to a shard to ensure atomic writes.
 ///
-/// Since the interface does not need to be exposed to users, the definition is placed in
-/// this file.
+/// Since the interface does not need to be exposed to users, the definition is
+/// placed in this file.
 message BatchWriteRequest {
   repeated ShardDeleteRequest deletes = 1;
   repeated ShardPutRequest puts = 2;
@@ -92,19 +95,26 @@ message BatchWriteRequest {
 message BatchWriteResponse {}
 
 message ShardPutRequest {
-    uint64 shard_id = 1;
-    engula.v1.PutRequest put = 2;
+  uint64 shard_id = 1;
+  engula.v1.PutRequest put = 2;
 }
 
 message ShardDeleteRequest {
-    uint64 shard_id = 1;
-    engula.v1.DeleteRequest delete = 2;
+  uint64 shard_id = 1;
+  engula.v1.DeleteRequest delete = 2;
 }
 
 message ShardGetRequest {
-    uint64 shard_id = 1;
-    engula.v1.GetRequest get = 2;
+  uint64 shard_id = 1;
+  engula.v1.GetRequest get = 2;
 }
+
+message ShardPrefixListRequest {
+  uint64 shard_id = 1;
+  bytes prefix = 2;
+}
+
+message ShardPrefixListResponse { repeated bytes values = 1; }
 
 message GetRootRequest {}
 
@@ -210,14 +220,14 @@ message ReplicaStats {
 }
 
 message CollectGroupDetailRequest {
-    /// The ID list of the group that needs to get the status, if it is empty, get all
-    /// the groups on the target machine.
-    repeated uint64 groups = 1;
+  /// The ID list of the group that needs to get the status, if it is empty, get
+  /// all the groups on the target machine.
+  repeated uint64 groups = 1;
 }
 
 message CollectGroupDetailResponse {
-    repeated ReplicaState replica_states = 1;
-    /// If a replica is the leader of group, it also needs to be responsible for filling
-    /// in the `GroupDesc`.
-    repeated GroupDesc group_descs = 2;
+  repeated ReplicaState replica_states = 1;
+  /// If a replica is the leader of group, it also needs to be responsible for
+  /// filling in the `GroupDesc`.
+  repeated GroupDesc group_descs = 2;
 }

--- a/src/server/src/node/engine/group.rs
+++ b/src/server/src/node/engine/group.rs
@@ -247,17 +247,21 @@ impl GroupEngine {
         Ok(())
     }
 
-    pub fn iter(&self) -> Result<GroupEngineIterator> {
-        use rocksdb::{IteratorMode, ReadOptions};
+    pub fn iter(&self, from: Option<Vec<u8>>) -> Result<GroupEngineIterator> {
+        use rocksdb::{Direction, IteratorMode, ReadOptions};
 
         let cf_handle = self
             .raw_db
             .cf_handle(&self.name)
             .expect("column family handle");
         let opts = ReadOptions::default();
-        let iter = self
-            .raw_db
-            .iterator_cf_opt(&cf_handle, opts, IteratorMode::Start);
+        let iter = if let Some(from) = from {
+            let mode = IteratorMode::From(&from, Direction::Forward);
+            self.raw_db.iterator_cf_opt(&cf_handle, opts, mode)
+        } else {
+            let mode = IteratorMode::Start;
+            self.raw_db.iterator_cf_opt(&cf_handle, opts, mode)
+        };
         GroupEngineIterator::new(iter)
     }
 

--- a/src/server/src/node/engine/group.rs
+++ b/src/server/src/node/engine/group.rs
@@ -247,7 +247,7 @@ impl GroupEngine {
         Ok(())
     }
 
-    pub fn iter(&self, from: Option<Vec<u8>>) -> Result<GroupEngineIterator> {
+    pub fn iter_from(&self, from: Vec<u8>) -> Result<GroupEngineIterator> {
         use rocksdb::{Direction, IteratorMode, ReadOptions};
 
         let cf_handle = self
@@ -255,13 +255,25 @@ impl GroupEngine {
             .cf_handle(&self.name)
             .expect("column family handle");
         let opts = ReadOptions::default();
-        let iter = if let Some(from) = from {
-            let mode = IteratorMode::From(&from, Direction::Forward);
-            self.raw_db.iterator_cf_opt(&cf_handle, opts, mode)
-        } else {
-            let mode = IteratorMode::Start;
-            self.raw_db.iterator_cf_opt(&cf_handle, opts, mode)
-        };
+        let iter = self.raw_db.iterator_cf_opt(
+            &cf_handle,
+            opts,
+            IteratorMode::From(&from, Direction::Forward),
+        );
+        GroupEngineIterator::new(iter)
+    }
+
+    pub fn iter(&self) -> Result<GroupEngineIterator> {
+        use rocksdb::{IteratorMode, ReadOptions};
+
+        let cf_handle = self
+            .raw_db
+            .cf_handle(&self.name)
+            .expect("column family handle");
+        let opts = ReadOptions::default();
+        let iter = self
+            .raw_db
+            .iterator_cf_opt(&cf_handle, opts, IteratorMode::Start);
         GroupEngineIterator::new(iter)
     }
 

--- a/src/server/src/node/replica/eval/cmd_prefix_list.rs
+++ b/src/server/src/node/replica/eval/cmd_prefix_list.rs
@@ -1,0 +1,34 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use engula_api::server::v1::{ShardPrefixListRequest, ShardPrefixListResponse};
+
+use crate::{node::engine::GroupEngine, Result};
+
+/// List the key-value pairs of the specified key prefix.
+pub async fn prefix_list(
+    engine: &GroupEngine,
+    req: &ShardPrefixListRequest,
+) -> Result<ShardPrefixListResponse> {
+    let prefix = &req.prefix;
+    let mut values = Vec::new();
+    let iter = engine.iter(Some(prefix.to_owned()))?;
+    for (key, value) in iter {
+        if !key.starts_with(prefix) {
+            break;
+        }
+        values.push(value.to_vec());
+    }
+    Ok(ShardPrefixListResponse { values })
+}

--- a/src/server/src/node/replica/eval/cmd_prefix_list.rs
+++ b/src/server/src/node/replica/eval/cmd_prefix_list.rs
@@ -23,7 +23,7 @@ pub async fn prefix_list(
 ) -> Result<ShardPrefixListResponse> {
     let prefix = &req.prefix;
     let mut values = Vec::new();
-    let iter = engine.iter(Some(prefix.to_owned()))?;
+    let iter = engine.iter_from(prefix.to_owned())?;
     for (key, value) in iter {
         if !key.starts_with(prefix) {
             break;

--- a/src/server/src/node/replica/eval/mod.rs
+++ b/src/server/src/node/replica/eval/mod.rs
@@ -15,11 +15,15 @@
 mod cmd_batch_write;
 mod cmd_delete;
 mod cmd_get;
+mod cmd_prefix_list;
 mod cmd_put;
 
 use engula_api::server::v1::ShardDesc;
 
-pub use self::{cmd_batch_write::batch_write, cmd_delete::delete, cmd_get::get, cmd_put::put};
+pub use self::{
+    cmd_batch_write::batch_write, cmd_delete::delete, cmd_get::get, cmd_prefix_list::prefix_list,
+    cmd_put::put,
+};
 use crate::serverpb::v1::EvalResult;
 
 pub fn add_shard(shard: ShardDesc) -> EvalResult {

--- a/src/server/src/node/replica/fsm/checkpoint.rs
+++ b/src/server/src/node/replica/fsm/checkpoint.rs
@@ -34,7 +34,7 @@ impl GroupSnapshotBuilder {
 #[crate::async_trait]
 impl SnapshotBuilder for GroupSnapshotBuilder {
     async fn checkpoint(&self, base_dir: &Path) -> Result<(ApplyState, GroupDesc)> {
-        let mut iter = self.engine.iter()?;
+        let mut iter = self.engine.iter(None)?;
         for i in 0.. {
             if write_partial_to_file(&mut iter, base_dir, i)
                 .await?

--- a/src/server/src/node/replica/fsm/checkpoint.rs
+++ b/src/server/src/node/replica/fsm/checkpoint.rs
@@ -34,7 +34,7 @@ impl GroupSnapshotBuilder {
 #[crate::async_trait]
 impl SnapshotBuilder for GroupSnapshotBuilder {
     async fn checkpoint(&self, base_dir: &Path) -> Result<(ApplyState, GroupDesc)> {
-        let mut iter = self.engine.iter(None)?;
+        let mut iter = self.engine.iter()?;
         for i in 0.. {
             if write_partial_to_file(&mut iter, base_dir, i)
                 .await?

--- a/src/server/src/node/replica/mod.rs
+++ b/src/server/src/node/replica/mod.rs
@@ -264,6 +264,10 @@ impl Replica {
                 let eval_result = eval::delete(&self.group_engine, req).await?;
                 (Some(eval_result), Response::Delete(DeleteResponse {}))
             }
+            Request::PrefixList(req) => {
+                let eval_result = eval::prefix_list(&self.group_engine, req).await?;
+                (None, Response::PreifxList(eval_result))
+            }
             Request::BatchWrite(req) => {
                 let eval_result = eval::batch_write(&self.group_engine, req).await?;
                 (eval_result, Response::BatchWrite(BatchWriteResponse {}))
@@ -485,6 +489,10 @@ impl DescObserver for LeaseStateObserver {
 pub(self) fn is_change_meta_request(request: &Request) -> bool {
     match request {
         Request::ChangeReplicas(_) | Request::CreateShard(_) => true,
-        Request::Get(_) | Request::Put(_) | Request::Delete(_) | Request::BatchWrite(_) => false,
+        Request::Get(_)
+        | Request::Put(_)
+        | Request::Delete(_)
+        | Request::BatchWrite(_)
+        | Request::PrefixList(_) => false,
     }
 }

--- a/src/server/src/node/replica/retry.rs
+++ b/src/server/src/node/replica/retry.rs
@@ -68,6 +68,9 @@ fn is_executable(descriptor: &GroupDesc, request: &GroupRequest) -> bool {
             Request::Delete(req) => {
                 is_target_shard_exists(descriptor, req.shard_id, &req.delete.as_ref().unwrap().key)
             }
+            Request::PrefixList(req) => {
+                is_target_shard_exists(descriptor, req.shard_id, &req.prefix)
+            }
             Request::BatchWrite(req) => {
                 for delete in &req.deletes {
                     if !is_target_shard_exists(

--- a/src/server/src/root/mod.rs
+++ b/src/server/src/root/mod.rs
@@ -25,19 +25,13 @@ use std::{
 };
 
 use engula_api::{
-    server::v1::{
-        report_request::GroupUpdates,
-        watch_response::{delete_event, update_event, DeleteEvent, UpdateEvent},
-        NodeDesc,
-    },
+    server::v1::{report_request::GroupUpdates, watch_response::*, NodeDesc},
     v1::{CollectionDesc, DatabaseDesc},
 };
 
+pub(crate) use self::schema::*;
+pub use self::watch::{WatchHub, Watcher, WatcherInitializer};
 use self::{schema::ReplicaNodes, store::RootStore};
-pub use self::{
-    schema::Schema,
-    watch::{WatchHub, Watcher, WatcherInitializer},
-};
 use crate::{
     node::{Node, Replica, ReplicaRouteTable},
     runtime::{Executor, TaskPriority},

--- a/src/server/src/root/schema.rs
+++ b/src/server/src/root/schema.rs
@@ -129,7 +129,7 @@ impl Schema {
     }
 
     pub async fn list_database(&self) -> Result<Vec<DatabaseDesc>> {
-        let vals = self.list(SYSTEM_DATABASE_COLLECTION_ID).await?;
+        let vals = self.list(&SYSTEM_DATABASE_COLLECTION_ID).await?;
         let mut databases = Vec::new();
         for val in vals {
             databases.push(
@@ -227,7 +227,7 @@ impl Schema {
     }
 
     pub async fn list_collection(&self) -> Result<Vec<CollectionDesc>> {
-        let vals = self.list(SYSTEM_DATABASE_COLLECTION_ID).await?;
+        let vals = self.list(&SYSTEM_DATABASE_COLLECTION_ID).await?;
         let mut collections = Vec::new();
         for val in vals {
             collections.push(
@@ -264,7 +264,7 @@ impl Schema {
     }
 
     pub async fn list_node(&self) -> Result<Vec<NodeDesc>> {
-        let vals = self.list(SYSTEM_NODE_COLLECTION_ID).await?;
+        let vals = self.list(&SYSTEM_NODE_COLLECTION_ID).await?;
         let mut nodes = Vec::new();
         for val in vals {
             nodes
@@ -311,7 +311,7 @@ impl Schema {
     }
 
     pub async fn list_group(&self) -> Result<Vec<GroupDesc>> {
-        let vals = self.list(SYSTEM_GROUP_COLLECTION_ID).await?;
+        let vals = self.list(&SYSTEM_GROUP_COLLECTION_ID).await?;
         let mut groups = Vec::new();
         for val in vals {
             groups.push(
@@ -322,7 +322,7 @@ impl Schema {
     }
 
     pub async fn list_group_state(&self) -> Result<Vec<GroupState>> {
-        let vals = self.list(SYSTEM_REPLICA_STATE_COLLECTION_ID).await?;
+        let vals = self.list(&SYSTEM_REPLICA_STATE_COLLECTION_ID).await?;
         let mut states: HashMap<u64, GroupState> = HashMap::new();
         for val in vals {
             let state = ReplicaState::decode(&*val)
@@ -685,9 +685,10 @@ impl Schema {
         self.store.delete(shard_id, key).await
     }
 
-    async fn list(&self, collection_id: u64) -> Result<Vec<Vec<u8>>> {
+    async fn list(&self, collection_id: &u64) -> Result<Vec<Vec<u8>>> {
+        let shard_id = Self::system_shard_id(collection_id);
         self.store
-            .list(collection_id.to_le_bytes().as_slice())
+            .list(shard_id, collection_id.to_le_bytes().as_slice())
             .await
     }
 

--- a/src/server/src/root/store.rs
+++ b/src/server/src/root/store.rs
@@ -22,11 +22,7 @@ use engula_api::{
     v1::{DeleteRequest, GetRequest, PutRequest},
 };
 
-use crate::{
-    bootstrap::{ROOT_GROUP_ID, ROOT_SHARD_ID},
-    node::replica::Replica,
-    Error, Result,
-};
+use crate::{bootstrap::ROOT_GROUP_ID, node::replica::Replica, Error, Result};
 
 pub struct RootStore {
     replica: Arc<Replica>,
@@ -55,19 +51,19 @@ impl RootStore {
         Ok(())
     }
 
-    pub async fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<()> {
+    pub async fn put(&self, shard_id: u64, key: Vec<u8>, value: Vec<u8>) -> Result<()> {
         self.submit_request(Put(ShardPutRequest {
-            shard_id: ROOT_SHARD_ID,
+            shard_id,
             put: Some(PutRequest { key, value }),
         }))
         .await?;
         Ok(())
     }
 
-    pub async fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
+    pub async fn get(&self, shard_id: u64, key: &[u8]) -> Result<Option<Vec<u8>>> {
         let resp = self
             .submit_request(Get(ShardGetRequest {
-                shard_id: ROOT_SHARD_ID,
+                shard_id,
                 get: Some(GetRequest {
                     key: key.to_owned(),
                 }),
@@ -85,9 +81,9 @@ impl RootStore {
         }
     }
 
-    pub async fn delete(&self, key: &[u8]) -> Result<()> {
+    pub async fn delete(&self, shard_id: u64, key: &[u8]) -> Result<()> {
         self.submit_request(Delete(ShardDeleteRequest {
-            shard_id: ROOT_SHARD_ID,
+            shard_id,
             delete: Some(DeleteRequest {
                 key: key.to_owned(),
             }),
@@ -101,7 +97,7 @@ impl RootStore {
         Ok(vec![])
     }
 
-    pub async fn submit_request(&self, req: Request) -> Result<GroupResponse> {
+    async fn submit_request(&self, req: Request) -> Result<GroupResponse> {
         use crate::node::replica::retry::execute;
 
         let epoch = self.replica.epoch();

--- a/src/server/tests/group_test.rs
+++ b/src/server/tests/group_test.rs
@@ -89,7 +89,7 @@ fn add_replica() {
 
         // 2. add replica to group
         let req = RequestBatchBuilder::new(node_1_id)
-            .add_replica(group_id, 2, new_replica_id, node_2_id)
+            .add_replica(group_id, 7, new_replica_id, node_2_id)
             .build();
         let resps = client_1.batch_group_requests(req).await.unwrap();
         assert_eq!(resps.len(), 1);


### PR DESCRIPTION
as pre-step of #766, it makes collections in `__system__` as "one init-shard per collection" and support list values in the collection(it also assumes that `__system__` database's shard doesn't need auto split)

closes #773