### PR TITLE
root: export root info via http api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "raft-engine",
  "rand 0.8.5",
  "rocksdb",
+ "serde_json",
  "socket2",
  "tempdir",
  "thiserror",
@@ -1488,6 +1489,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
+name = "ryu"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,6 +1518,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -26,6 +26,7 @@ tracing = "0.1"
 uuid = { version = "1.1.1", features = ["v4"] }
 num_cpus = "1.13"
 rand = "0.8"
+serde_json = "1.0"
 
 [dependencies.raft]
 git = "https://github.com/w41ter/raft-rs.git"

--- a/src/server/src/bootstrap.rs
+++ b/src/server/src/bootstrap.rs
@@ -115,7 +115,7 @@ async fn bootstrap_services(addr: &str, server: Server) -> Result<()> {
         .add_service(NodeServer::new(server.clone()))
         .add_service(RaftServer::new(server.clone()))
         .add_service(RootServer::new(server.clone()))
-        .add_service(make_admin_service())
+        .add_service(make_admin_service(server.clone()))
         .serve_with_incoming(listener)
         .await?;
 

--- a/src/server/src/node/mod.rs
+++ b/src/server/src/node/mod.rs
@@ -485,7 +485,7 @@ impl Node {
                     ns.orphan_replica_count += 1;
                 }
                 let replica_state = replica.replica_state();
-                if replica_state.role == RaftRole::Leader  as i32 {
+                if replica_state.role == RaftRole::Leader as i32 {
                     ns.leader_count += 1;
                     let gs = GroupStats {
                         group_id: info.group_id,

--- a/src/server/src/node/mod.rs
+++ b/src/server/src/node/mod.rs
@@ -485,7 +485,7 @@ impl Node {
                     ns.orphan_replica_count += 1;
                 }
                 let replica_state = replica.replica_state();
-                if replica_state.role == RaftRole::Leader.into() {
+                if replica_state.role == RaftRole::Leader  as i32 {
                     ns.leader_count += 1;
                     let gs = GroupStats {
                         group_id: info.group_id,
@@ -530,7 +530,7 @@ impl Node {
                 }
 
                 let state = replica.replica_state();
-                if state.role == RaftRole::Leader.into() {
+                if state.role == RaftRole::Leader as i32 {
                     descriptors.push(replica.descriptor());
                 }
                 states.push(state);

--- a/src/server/src/node/replica/state.rs
+++ b/src/server/src/node/replica/state.rs
@@ -63,7 +63,7 @@ impl LeaseState {
 
     #[inline]
     pub fn is_raft_leader(&self) -> bool {
-        self.replica_state.role == RaftRole::Leader.into()
+        self.replica_state.role == RaftRole::Leader as i32
     }
 
     /// At least one log for the current term has been applied?
@@ -163,7 +163,7 @@ impl LeaseStateObserver {
     fn update_descriptor(&self, descriptor: GroupDesc) -> bool {
         let mut lease_state = self.lease_state.lock().unwrap();
         lease_state.descriptor = descriptor;
-        lease_state.replica_state.role == RaftRole::Leader.into()
+        lease_state.replica_state.role == RaftRole::Leader as i32
     }
 }
 

--- a/src/server/src/root/allocator/policy_leader_cnt.rs
+++ b/src/server/src/root/allocator/policy_leader_cnt.rs
@@ -80,11 +80,11 @@ impl<T: AllocSource> LeaderCountPolicy<T> {
         let groups = self.alloc_source.groups();
         for (replica, group_id) in node_replicas
             .iter()
-            .filter(|(r, g)| *g != ROOT_GROUP_ID || r.role == ReplicaRole::Voter.into())
+            .filter(|(r, g)| *g != ROOT_GROUP_ID || r.role == ReplicaRole::Voter as i32)
         {
             let replica_state = self.alloc_source.replica_state(&replica.id).unwrap();
             // .ok_or(crate::Error::GroupNotFound(*group_id))?;
-            if replica_state.role != RaftRole::Leader.into() {
+            if replica_state.role != RaftRole::Leader as i32 {
                 continue;
             }
 

--- a/src/server/src/root/allocator/sim_test.rs
+++ b/src/server/src/root/allocator/sim_test.rs
@@ -516,7 +516,7 @@ impl MockInfoProvider {
         let groups = self.groups();
         let mut node_leader = HashMap::new();
         for r in &rs {
-            if r.role != RaftRole::Leader.into() {
+            if r.role != RaftRole::Leader as i32 {
                 continue;
             }
             let group = groups.get(&r.group_id).unwrap();
@@ -645,7 +645,7 @@ impl MockInfoProvider {
         let state = self.replicas.lock().unwrap();
         let mut node_leaders: HashMap<u64, Vec<u64>> = HashMap::new();
         let rs = state.values();
-        for r in rs.filter(|s| s.role == RaftRole::Leader.into()) {
+        for r in rs.filter(|s| s.role == RaftRole::Leader as i32) {
             let n = groups
                 .descs
                 .get(&r.group_id)

--- a/src/server/src/root/job.rs
+++ b/src/server/src/root/job.rs
@@ -310,7 +310,7 @@ impl Root {
             .await?
             .ok_or(crate::Error::GroupNotFound(group.id))?;
 
-        if replica_state.role == RaftRole::Leader.into() {
+        if replica_state.role == RaftRole::Leader as i32 {
             if let Some(target_replica) = group.replicas.iter().find(|e| e.id != remove_replica) {
                 info!(
                     "transfer group {} leader from {} to {}",
@@ -361,11 +361,11 @@ impl Root {
 
         let mut group_leader = None;
         for replica in &group.replicas {
-            if replica.role != ReplicaRole::Voter.into() {
+            if replica.role != ReplicaRole::Voter as i32 {
                 continue;
             }
             if let Some(rs) = schema.get_replica_state(group_id, replica.id).await? {
-                if rs.role == RaftRole::Leader.into() {
+                if rs.role == RaftRole::Leader as i32 {
                     group_leader = Some(replica);
                     break;
                 }

--- a/src/server/src/root/mod.rs
+++ b/src/server/src/root/mod.rs
@@ -252,10 +252,10 @@ impl Root {
                             "shards": g.shards.iter().map(|s| {
                                 let part = match s.partition.as_ref().unwrap() {
                                     shard_desc::Partition::Hash(shard_desc::HashPartition {slot_id, slots}) => {
-                                        format!("hash: {} of {}", slot_id, slots)
+                                        format!("hash: {slot_id} of {slots}")
                                     },
                                     shard_desc::Partition::Range(shard_desc::RangePartition {start, end}) => {
-                                        format!("range: {:?} to {:?}", start, end)
+                                        format!("range: {start:?} to {end:?}")
                                     },
                                 };
                                 json!({
@@ -273,7 +273,7 @@ impl Root {
                     "collections": collections.iter().filter(|c|c.db == d.id).map(|c| {
                         let mode = match c.partition.as_ref().unwrap() {
                             co_desc::Partition::Hash(co_desc::HashPartition { slots }) => {
-                                format!("hash({})", slots)
+                                format!("hash({slots})")
                             },
                             co_desc::Partition::Range(co_desc::RangePartition {}) => {
                                 "range".to_owned()

--- a/src/server/src/root/mod.rs
+++ b/src/server/src/root/mod.rs
@@ -210,6 +210,8 @@ impl Root {
             .flat_map(|g| g.replicas.iter().map(|r| (r, g.id)).collect::<Vec<_>>())
             .collect::<Vec<_>>();
         let states = schema.list_replica_state().await?;
+        let dbs = schema.list_database().await?;
+        let collections = schema.list_collection().await?;
 
         let info = json!(
             {
@@ -254,6 +256,11 @@ impl Root {
                         }
                     )
                 }).collect::<Vec<_>>(),
+                "databases": dbs.iter().map(|d| json!({
+                    "id": d.id,
+                    "name": d.name,
+                    "collections": collections.iter().filter(|c|c.db == d.id).map(|c| json!({"id": c.id, "name": c.name})).collect::<Vec<_>>(),
+                })).collect::<Vec<_>>(),
             }
         );
 

--- a/src/server/src/root/schema.rs
+++ b/src/server/src/root/schema.rs
@@ -268,13 +268,12 @@ impl Schema {
     }
 
     pub async fn list_collection(&self) -> Result<Vec<CollectionDesc>> {
-        let vals = self.list(&SYSTEM_DATABASE_COLLECTION_ID).await?;
+        let vals = self.list(&SYSTEM_COLLECTION_COLLECTION_ID).await?;
         let mut collections = Vec::new();
         for val in vals {
-            collections.push(
-                CollectionDesc::decode(&*val)
-                    .map_err(|_| Error::InvalidData("collection desc".into()))?,
-            );
+            let c = CollectionDesc::decode(&*val)
+                .map_err(|_| Error::InvalidData("collection desc".into()))?;
+            collections.push(c);
         }
         Ok(collections)
     }

--- a/src/server/src/root/schema.rs
+++ b/src/server/src/root/schema.rs
@@ -173,11 +173,11 @@ impl Schema {
 
             let mut group_leader = None;
             for replica in &group.replicas {
-                if replica.role != ReplicaRole::Voter.into() {
+                if replica.role != ReplicaRole::Voter as i32 {
                     continue;
                 }
                 if let Some(rs) = self.get_replica_state(group_id, replica.id).await? {
-                    if rs.role == RaftRole::Leader.into() {
+                    if rs.role == RaftRole::Leader as i32 {
                         group_leader = Some(replica);
                         break;
                     }
@@ -404,7 +404,7 @@ impl Schema {
             match states.entry(state.group_id) {
                 Entry::Occupied(mut ent) => {
                     let group = ent.get_mut();
-                    if state.role == RaftRole::Leader.into() {
+                    if state.role == RaftRole::Leader as i32 {
                         (*group).leader_id = Some(state.replica_id);
                     } else if (*group).leader_id == Some(state.replica_id) {
                         (*group).leader_id = None;
@@ -415,7 +415,7 @@ impl Schema {
                     (*group).replicas.push(state);
                 }
                 Entry::Vacant(ent) => {
-                    let leader_id = if state.role == RaftRole::Leader.into() {
+                    let leader_id = if state.role == RaftRole::Leader as i32 {
                         Some(state.replica_id)
                     } else {
                         None


### PR DESCRIPTION
closes #835

all in one API, it recommends using [jq](https://stedolan.github.io/jq/) to filter detailed data

```shell
curl -s  http://localhost:21805/admin/metadata | jq '.'
```

```json
{
  "databases": [
    {
      "collections": [
        {
          "id": 1,
          "mode": "range",
          "name": "collection"
        },
        {
          "id": 2,
          "mode": "range",
          "name": "database"
        },
        {
          "id": 5,
          "mode": "range",
          "name": "group"
        },
        {
          "id": 3,
          "mode": "range",
          "name": "meta"
        },
        {
          "id": 4,
          "mode": "range",
          "name": "node"
        },
        {
          "id": 6,
          "mode": "range",
          "name": "replica_state"
        }
      ],
      "id": 1,
      "name": "__system__"
    },
    {
      "collections": [
        {
          "id": 7,
          "mode": "hash(3)",
          "name": "test_co"
        }
      ],
      "id": 2,
      "name": "test_db"
    }
  ],
  "groups": [
    {
      "epoch": 7,
      "id": 0,
      "replicas": [
        {
          "id": 1,
          "node": 0,
          "raft_role": 2,
          "replica_role": 0,
          "term": 3
        }
      ],
      "shards": [
        {
          "collection": 1,
          "id": 1,
          "partition": "range: [] to []"
        },
        {
          "collection": 2,
          "id": 2,
          "partition": "range: [] to []"
        },
        {
          "collection": 3,
          "id": 3,
          "partition": "range: [] to []"
        },
        {
          "collection": 4,
          "id": 4,
          "partition": "range: [] to []"
        },
        {
          "collection": 5,
          "id": 5,
          "partition": "range: [] to []"
        },
        {
          "collection": 6,
          "id": 6,
          "partition": "range: [] to []"
        }
      ]
    },
    {
      "epoch": 4,
      "id": 1,
      "replicas": [
        {
          "id": 2,
          "node": 0,
          "raft_role": 2,
          "replica_role": 0,
          "term": 3
        }
      ],
      "shards": [
        {
          "collection": 7,
          "id": 9,
          "partition": "hash: 2 of 3"
        },
        {
          "collection": 7,
          "id": 8,
          "partition": "hash: 1 of 3"
        },
        {
          "collection": 7,
          "id": 7,
          "partition": "hash: 0 of 3"
        }
      ]
    }
  ],
  "nodes": [
    {
      "addr": "127.0.0.1:21805",
      "id": 0,
      "replicas": [
        {
          "group": 0,
          "id": 1,
          "raft_role": 2,
          "replica_role": 0
        },
        {
          "group": 1,
          "id": 2,
          "raft_role": 2,
          "replica_role": 0
        }
      ]
    }
  ]
}
```