### PR TITLE
test: support disable auto balance in unit test

### DIFF
--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -15,7 +15,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use engula_server::Result;
+use engula_server::{Config, Result};
 
 #[derive(Parser)]
 #[clap(version)]
@@ -60,7 +60,14 @@ impl StartCommand {
         use engula_server::runtime::ExecutorOwner;
 
         let owner = ExecutorOwner::new(num_cpus::get());
-        engula_server::run(owner.executor(), self.db, self.addr, self.init, self.join)
+        engula_server::run(
+            owner.executor(),
+            self.db,
+            self.addr,
+            self.init,
+            self.join,
+            Config::default(),
+        )
     }
 }
 

--- a/src/server/src/lib.rs
+++ b/src/server/src/lib.rs
@@ -29,7 +29,7 @@ mod service;
 pub use tonic::async_trait;
 
 pub use crate::{
-    bootstrap::run,
+    bootstrap::{run, Config},
     error::{Error, Result},
     service::Server,
 };

--- a/src/server/src/root/allocator/sim_test.rs
+++ b/src/server/src/root/allocator/sim_test.rs
@@ -31,7 +31,7 @@ fn sim_boostrap_join_node_balance() {
     let executor = executor_owner.executor();
     executor.block_on(async {
         let p = Arc::new(MockInfoProvider::new());
-        let a = Allocator::new(p.clone(), REPLICA_PER_GROUP);
+        let a = Allocator::new(p.clone(), AllocatorConfig::default());
 
         println!("1. boostrap and no need rebalance");
         p.set_groups(vec![GroupDesc {

--- a/src/server/tests/bootstrap_test.rs
+++ b/src/server/tests/bootstrap_test.rs
@@ -15,7 +15,7 @@
 
 mod helper;
 
-use engula_server::Result;
+use engula_server::{Config, Result};
 
 use crate::helper::{
     client::node_client_with_retry, context::*, init::setup_panic_hook, runtime::block_on_current,
@@ -31,7 +31,7 @@ fn init() {
 fn bootstrap_cluster() -> Result<()> {
     let ctx = TestContext::new("bootstrap-cluster");
     let node_1_addr = ctx.next_listen_address();
-    ctx.spawn_server(1, &node_1_addr, true, vec![]);
+    ctx.spawn_server(1, &node_1_addr, true, vec![], Config::default());
 
     block_on_current(async {
         node_client_with_retry(&node_1_addr).await;
@@ -45,10 +45,16 @@ fn bootstrap_cluster() -> Result<()> {
 fn join_node() -> Result<()> {
     let ctx = TestContext::new("join-node");
     let node_1_addr = ctx.next_listen_address();
-    ctx.spawn_server(1, &node_1_addr, true, vec![]);
+    ctx.spawn_server(1, &node_1_addr, true, vec![], Config::default());
 
     let node_2_addr = ctx.next_listen_address();
-    ctx.spawn_server(2, &node_2_addr, false, vec![node_1_addr.clone()]);
+    ctx.spawn_server(
+        2,
+        &node_2_addr,
+        false,
+        vec![node_1_addr.clone()],
+        Config::default(),
+    );
 
     block_on_current(async {
         node_client_with_retry(&node_1_addr).await;

--- a/src/server/tests/group_test.rs
+++ b/src/server/tests/group_test.rs
@@ -18,6 +18,7 @@ mod helper;
 use std::time::Duration;
 
 use engula_api::server::v1::*;
+use engula_server::Config;
 use helper::context::TestContext;
 use tracing::info;
 
@@ -33,7 +34,7 @@ fn init() {
 fn add_replica() {
     block_on_current(async {
         let ctx = TestContext::new("add-replica");
-        let nodes = ctx.bootstrap_servers(2).await;
+        let nodes = ctx.bootstrap_servers(2, disable_replica_balance()).await;
         let c = ClusterClient::new(nodes).await;
 
         let group_id = 0;
@@ -60,7 +61,7 @@ fn add_replica() {
 fn create_group_with_multi_replicas() {
     block_on_current(async {
         let ctx = TestContext::new("create-group-with-multi-replicas");
-        let nodes = ctx.bootstrap_servers(4).await;
+        let nodes = ctx.bootstrap_servers(4, disable_replica_balance()).await;
         let c = ClusterClient::new(nodes).await;
 
         let group_id = 100000000;
@@ -114,7 +115,7 @@ fn create_group_with_multi_replicas() {
 fn promote_to_cluster_from_single_node() {
     block_on_current(async {
         let ctx = TestContext::new("promote-to-cluster");
-        let nodes = ctx.bootstrap_servers(3).await;
+        let nodes = ctx.bootstrap_servers(3, disable_replica_balance()).await;
         let c = ClusterClient::new(nodes).await;
 
         let root_group_id = 0;
@@ -133,4 +134,11 @@ fn promote_to_cluster_from_single_node() {
         }
         panic!("could not promote root group to cluster");
     });
+}
+
+fn disable_replica_balance() -> Config {
+    let mut cfg = Config::default();
+    cfg.allocator.enable_replica_balance = false;
+    cfg.allocator.enable_replica_balance = false;
+    cfg
 }

--- a/src/server/tests/migration_test.rs
+++ b/src/server/tests/migration_test.rs
@@ -19,6 +19,7 @@ mod helper;
 use std::time::Duration;
 
 use engula_api::{server::v1::*, v1::PutRequest};
+use engula_server::Config;
 use tracing::info;
 
 use crate::helper::{client::*, context::*, init::setup_panic_hook, runtime::block_on_current};
@@ -63,7 +64,7 @@ async fn insert(c: &ClusterClient, group_id: u64, shard_id: u64, range: std::ops
 fn single_replica_empty_shard_migration() {
     block_on_current(async {
         let ctx = TestContext::new("single-replica-empty-shard-migration");
-        let nodes = ctx.bootstrap_servers(2).await;
+        let nodes = ctx.bootstrap_servers(2, disable_shard_balance()).await;
         let c = ClusterClient::new(nodes).await;
         let node_1_id = 0;
         let node_2_id = 1;
@@ -136,7 +137,7 @@ fn single_replica_empty_shard_migration() {
 fn single_replica_migration() {
     block_on_current(async {
         let ctx = TestContext::new("single-replica-migration");
-        let nodes = ctx.bootstrap_servers(2).await;
+        let nodes = ctx.bootstrap_servers(2, disable_shard_balance()).await;
         let c = ClusterClient::new(nodes).await;
         let node_1_id = 0;
         let node_2_id = 1;
@@ -239,7 +240,7 @@ async fn create_group(
 fn basic_migration() {
     block_on_current(async {
         let ctx = TestContext::new("basic-migration");
-        let nodes = ctx.bootstrap_servers(3).await;
+        let nodes = ctx.bootstrap_servers(3, disable_shard_balance()).await;
         let c = ClusterClient::new(nodes).await;
         let node_1_id = 0;
         let node_2_id = 1;
@@ -303,4 +304,10 @@ fn basic_migration() {
 
         tokio::time::sleep(Duration::from_secs(3)).await;
     });
+}
+
+fn disable_shard_balance() -> Config {
+    let mut cfg = Config::default();
+    cfg.allocator.enable_shard_balance = false;
+    cfg
 }


### PR DESCRIPTION
Support disable auto rebalance via allocator config in the unit test.

For example, if we want to test & assert shard migration results, disabling shard balance can stabilize our shard location assertion

https://github.com/engula/engula/runs/7313890135?check_suite_focus=true