### PR TITLE
*: add root group epoch for RootDesc

### DIFF
--- a/src/api/engula/server/v1/error.proto
+++ b/src/api/engula/server/v1/error.proto
@@ -66,7 +66,7 @@ message NotLeader {
 /// not the replica of root group (or root group leader).
 message NotRoot {
     /// `root` contains the known root members of the node, the first most likely being the leader.
-    repeated string root = 1;
+    RootDesc root = 1;
 }
 
 /// The epoch of metadata carried by the request does not match the epoch of target replica.

--- a/src/api/engula/server/v1/metadata.proto
+++ b/src/api/engula/server/v1/metadata.proto
@@ -28,6 +28,12 @@ message NodeCapacity {
   uint64 leader_count = 3;
 }
 
+message RootDesc {
+  /// The epoch of root group which indicates the freshness of root nodes.
+  uint64 epoch = 1;
+  repeated NodeDesc root_nodes = 2;
+}
+
 message ShardDesc {
   uint64 id = 1;
   uint64 collection_id = 2;

--- a/src/api/engula/server/v1/node.proto
+++ b/src/api/engula/server/v1/node.proto
@@ -131,7 +131,7 @@ message ShardPrefixListResponse { repeated bytes values = 1; }
 
 message GetRootRequest {}
 
-message GetRootResponse { repeated string addrs = 1; }
+message GetRootResponse { RootDesc root = 1; }
 
 message CreateReplicaRequest {
   uint64 replica_id = 1;
@@ -194,7 +194,9 @@ message HeartbeatRequest {
 
 message HeartbeatResponse {
   uint64 timestamp = 1;
-  repeated PiggybackResponse piggybacks = 2;
+  /// The epoch of root group which contained in node's `RootDesc`.
+  uint64 root_epoch = 2;
+  repeated PiggybackResponse piggybacks = 3;
 }
 
 message PiggybackRequest {
@@ -213,7 +215,7 @@ message PiggybackResponse {
   }
 }
 
-message SyncRootRequest { repeated NodeDesc roots = 1; }
+message SyncRootRequest { RootDesc root = 1; }
 
 message SyncRootResponse {}
 

--- a/src/api/engula/server/v1/root.proto
+++ b/src/api/engula/server/v1/root.proto
@@ -72,7 +72,7 @@ message JoinNodeRequest {
 message JoinNodeResponse {
   bytes cluster_id = 1;
   uint64 node_id = 2;
-  repeated NodeDesc roots = 3;
+  RootDesc root = 3;
 }
 
 message ReportRequest {

--- a/src/api/src/error.rs
+++ b/src/api/src/error.rs
@@ -124,8 +124,10 @@ impl Error {
     }
 
     #[inline]
-    pub fn not_root_leader(root: Vec<String>) -> Self {
-        Self::with_detail_value(error_detail_union::Value::NotRoot(NotRoot { root }))
+    pub fn not_root_leader(root: RootDesc) -> Self {
+        Self::with_detail_value(error_detail_union::Value::NotRoot(NotRoot {
+            root: Some(root),
+        }))
     }
 
     #[inline]

--- a/src/client/src/node_client.rs
+++ b/src/client/src/node_client.rs
@@ -37,7 +37,11 @@ impl Client {
         let mut client = self.client.clone();
         let req = GetRootRequest::default();
         let res = client.get_root(req).await?;
-        Ok(res.into_inner().addrs)
+        Ok(res
+            .into_inner()
+            .root
+            .map(|r| r.root_nodes.into_iter().map(|n| n.addr).collect())
+            .unwrap_or_default())
     }
 
     // NOTE: This method is always called by the root group.

--- a/src/client/src/root_client.rs
+++ b/src/client/src/root_client.rs
@@ -133,7 +133,13 @@ impl Client {
             Ok(res) => Ok(res),
             Err(status) => {
                 let err = not_root(Error::decode(status.details())).ok_or(status)?;
-                let candidates = err.root;
+                let candidates = err
+                    .root
+                    .unwrap_or_default()
+                    .root_nodes
+                    .into_iter()
+                    .map(|n| n.addr)
+                    .collect::<Vec<_>>();
                 *client = find_root_client(candidates.as_slice()).await?;
                 Ok(op(client.clone()).await?)
             }

--- a/src/server/proto/v1/metadata.proto
+++ b/src/server/proto/v1/metadata.proto
@@ -40,10 +40,6 @@ message NodeIdent {
   uint64 node_id = 2;
 }
 
-message RootDesc {
-  repeated engula.server.v1.NodeDesc root_nodes = 1;
-}
-
 enum ReplicaLocalState {
   /// With membership, but couldn't supply service.  It is used in group creation.
   INITIAL = 0;

--- a/src/server/src/bootstrap.rs
+++ b/src/server/src/bootstrap.rs
@@ -187,7 +187,7 @@ async fn try_join_cluster(
                     debug!("issue join request to root server success");
                     let node_ident =
                         save_node_ident(node.state_engine(), res.cluster_id, res.node_id).await;
-                    node.update_root(res.roots).await?;
+                    node.update_root(res.root.unwrap_or_default()).await?;
                     return node_ident;
                 }
                 Err(e) => {
@@ -284,7 +284,11 @@ async fn write_initial_cluster_data(node: &Node, addr: &str) -> Result<()> {
         addr: addr.to_owned(),
         ..Default::default()
     };
-    node.update_root(vec![root_node]).await?;
+    let root_desc = RootDesc {
+        epoch: INITIAL_EPOCH,
+        root_nodes: vec![root_node],
+    };
+    node.update_root(root_desc).await?;
 
     Ok(())
 }

--- a/src/server/src/node/job/report_state.rs
+++ b/src/server/src/node/job/report_state.rs
@@ -79,8 +79,8 @@ async fn wait_state_updates(
 
 async fn load_roots(state_engine: &StateEngine) -> Vec<String> {
     loop {
-        if let Some(roots) = state_engine.load_root_nodes().await.unwrap() {
-            return roots.into_iter().map(|d| d.addr).collect();
+        if let Some(desc) = state_engine.load_root_desc().await.unwrap() {
+            return desc.root_nodes.into_iter().map(|d| d.addr).collect();
         }
         crate::runtime::time::sleep(Duration::from_millis(10)).await;
     }
@@ -91,8 +91,8 @@ async fn report_state_updates(roots: &mut Vec<String>, request: ReportRequest) {
         for root in roots.iter() {
             match issue_report_request(root.to_owned(), &request).await {
                 Ok(()) => return,
-                Err(Error::NotRootLeader(recommends)) => {
-                    *roots = recommends;
+                Err(Error::NotRootLeader(root)) => {
+                    *roots = root.root_nodes.into_iter().map(|n| n.addr).collect();
                     continue 'OUTER;
                 }
                 Err(err) => {

--- a/src/server/src/root/job.rs
+++ b/src/server/src/root/job.rs
@@ -23,7 +23,7 @@ use tokio::time;
 use tracing::{info, trace, warn};
 
 use super::{allocator::*, Root, Schema};
-use crate::{bootstrap::ROOT_GROUP_ID, Result, root::schema::ReplicaNodes};
+use crate::{bootstrap::ROOT_GROUP_ID, root::schema::ReplicaNodes, Result};
 
 impl Root {
     pub async fn send_heartbeat(&self, schema: Schema) -> Result<()> {

--- a/src/server/src/service/root.rs
+++ b/src/server/src/service/root.rs
@@ -49,13 +49,13 @@ impl root_server::Root for Server {
         let capacity = request
             .capacity
             .ok_or_else(|| Error::InvalidArgument("capacity is required".into()))?;
-        let (cluster_id, node, roots) = self
+        let (cluster_id, node, root) = self
             .wrap(self.root.join(request.addr, capacity).await)
             .await?;
         Ok::<Response<JoinNodeResponse>, Status>(Response::new(JoinNodeResponse {
             cluster_id,
             node_id: node.id,
-            roots: roots.into(),
+            root: Some(root),
         }))
     }
 


### PR DESCRIPTION
This is the leading PR of root service discovery of #846. The epoch number is added to the return value of the `get_root` rpc, which is used to determine the old and new root desc, so that the client can judge which node's root list is more freshness, so as to achieve a convergence state.