### PR TITLE
root: refine root allocator 

### DIFF
--- a/src/api/engula/server/v1/metadata.proto
+++ b/src/api/engula/server/v1/metadata.proto
@@ -92,6 +92,7 @@ message ReplicaState {
   uint64 term = 3;
   uint64 voted_for = 4;
   RaftRole role = 5;
+  uint64 node_id = 6;
 }
 
 enum RaftRole {

--- a/src/server/src/node/replica/state.rs
+++ b/src/server/src/node/replica/state.rs
@@ -144,6 +144,7 @@ impl LeaseStateObserver {
             term,
             voted_for,
             role: role.into(),
+            node_id: self.info.node_id,
         };
         let mut lease_state = self.lease_state.lock().unwrap();
         lease_state.leader_id = leader_id;

--- a/src/server/src/root/allocator/mod.rs
+++ b/src/server/src/root/allocator/mod.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use engula_api::server::v1::{GroupDesc, NodeDesc, ReplicaDesc};
+use engula_api::server::v1::{GroupDesc, NodeDesc};
 use serde::{Deserialize, Serialize};
 
 use self::{
@@ -203,7 +203,7 @@ impl<T: AllocSource> Allocator<T> {
     /// Allocate new replica in one group.
     pub async fn allocate_group_replica(
         &self,
-        existing_replicas: Vec<ReplicaDesc>,
+        existing_replicas: Vec<u64>,
         wanted_count: usize,
     ) -> Result<Vec<NodeDesc>> {
         self.alloc_source.refresh_all().await?;

--- a/src/server/src/root/allocator/mod.rs
+++ b/src/server/src/root/allocator/mod.rs
@@ -137,7 +137,7 @@ impl<T: AllocSource> Allocator<T> {
 
         self.alloc_source.refresh_all().await?;
 
-        if self.alloc_source.nodes().len() < self.config.replicas_per_group {
+        if self.alloc_source.nodes(false).len() < self.config.replicas_per_group {
             // group alloctor start work after node_count > replicas_per_group.
             return Ok(GroupAction::Noop);
         }
@@ -188,7 +188,7 @@ impl<T: AllocSource> Allocator<T> {
 
         self.alloc_source.refresh_all().await?;
 
-        if self.alloc_source.nodes().len() < self.config.replicas_per_group {
+        if self.alloc_source.nodes(false).len() < self.config.replicas_per_group {
             return Ok(Vec::new());
         }
 
@@ -240,7 +240,7 @@ impl<T: AllocSource> Allocator<T> {
         // 2 remove groups from unmatch cpu-quota nodes.
         // 3. remove groups with lowest migration cost.
         self.alloc_source
-            .nodes()
+            .nodes(false)
             .iter()
             .take(want_remove)
             .map(|n| n.id)
@@ -250,7 +250,7 @@ impl<T: AllocSource> Allocator<T> {
     fn desired_groups(&self) -> usize {
         let total_cpus = self
             .alloc_source
-            .nodes()
+            .nodes(false)
             .iter()
             .map(|n| n.capacity.as_ref().unwrap().cpu_nums)
             .fold(0_f64, |acc, x| acc + x);

--- a/src/server/src/root/allocator/policy_leader_cnt.rs
+++ b/src/server/src/root/allocator/policy_leader_cnt.rs
@@ -42,7 +42,7 @@ impl<T: AllocSource> LeaderCountPolicy<T> {
 
     pub fn compute_balance(&self) -> Result<LeaderAction> {
         let mean = self.mean_leader_count();
-        let candidate_nodes = self.alloc_source.nodes();
+        let candidate_nodes = self.alloc_source.nodes(true);
         let ranked_nodes = Self::rank_nodes_for_leader(candidate_nodes, mean);
         trace!(
             scored_nodes = ?ranked_nodes.iter().map(|(n, s)| format!("{}-{}({:?})", n.id, n.capacity.as_ref().unwrap().leader_count, s)).collect::<Vec<_>>(),
@@ -180,7 +180,7 @@ impl<T: AllocSource> LeaderCountPolicy<T> {
     }
 
     fn mean_leader_count(&self) -> f64 {
-        let nodes = self.alloc_source.nodes();
+        let nodes = self.alloc_source.nodes(true);
         let total_leaders = nodes
             .iter()
             .map(|n| n.capacity.as_ref().unwrap().leader_count)

--- a/src/server/src/root/allocator/policy_replica_cnt.rs
+++ b/src/server/src/root/allocator/policy_replica_cnt.rs
@@ -38,7 +38,7 @@ impl<T: AllocSource> ReplicaCountPolicy<T> {
         existing_replica_nodes: Vec<u64>,
         wanted_count: usize,
     ) -> Result<Vec<NodeDesc>> {
-        let mut candidate_nodes = self.alloc_source.nodes();
+        let mut candidate_nodes = self.alloc_source.nodes(true);
 
         // skip the nodes already have group replicas.
         candidate_nodes.retain(|n| !existing_replica_nodes.iter().any(|rn| *rn == n.id));
@@ -55,7 +55,7 @@ impl<T: AllocSource> ReplicaCountPolicy<T> {
 
     pub fn compute_balance(&self) -> Result<Vec<ReplicaAction>> {
         let mean_cnt = self.mean_replica_count();
-        let candidate_nodes = self.alloc_source.nodes();
+        let candidate_nodes = self.alloc_source.nodes(true);
 
         let ranked_candidates = Self::rank_node_for_balance(candidate_nodes, mean_cnt);
         trace!(
@@ -146,7 +146,7 @@ impl<T: AllocSource> ReplicaCountPolicy<T> {
     }
 
     fn mean_replica_count(&self) -> f64 {
-        let nodes = self.alloc_source.nodes();
+        let nodes = self.alloc_source.nodes(true);
         let total_replicas = nodes
             .iter()
             .map(|n| n.capacity.as_ref().unwrap().replica_count)

--- a/src/server/src/root/allocator/policy_replica_cnt.rs
+++ b/src/server/src/root/allocator/policy_replica_cnt.rs
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{cmp::Ordering, collections::HashMap, sync::Arc};
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use engula_api::server::v1::{NodeDesc, ReplicaDesc};
 use tracing::trace;
@@ -31,13 +35,13 @@ impl<T: AllocSource> ReplicaCountPolicy<T> {
 
     pub fn allocate_group_replica(
         &self,
-        existing_replicas: Vec<ReplicaDesc>,
+        existing_replica_nodes: Vec<u64>,
         wanted_count: usize,
     ) -> Result<Vec<NodeDesc>> {
         let mut candidate_nodes = self.alloc_source.nodes();
 
         // skip the nodes already have group replicas.
-        candidate_nodes.retain(|n| !existing_replicas.iter().any(|r| r.node_id == n.id));
+        candidate_nodes.retain(|n| !existing_replica_nodes.iter().any(|rn| *rn == n.id));
 
         // sort by alloc score
         candidate_nodes.sort_by(|n1, n2| {
@@ -77,7 +81,28 @@ impl<T: AllocSource> ReplicaCountPolicy<T> {
         ranked_nodes: &[(NodeDesc, BalanceStatus)],
     ) -> Option<ReplicaAction> {
         let mean = self.mean_replica_count();
-        let groups = self.alloc_source.groups();
+        let mut groups = self
+            .alloc_source
+            .groups()
+            .into_iter()
+            .map(|(group, desc)| {
+                (
+                    group,
+                    desc.replicas
+                        .iter()
+                        .map(|r| r.node_id)
+                        .collect::<HashSet<u64>>(),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+
+        let replica_states = self.alloc_source.replica_states();
+        for replica_state in replica_states {
+            if let Some(g) = groups.get_mut(&replica_state.group_id) {
+                g.insert(replica_state.node_id);
+            }
+        }
+
         for (target, state) in ranked_nodes.iter().rev() {
             if *state != BalanceStatus::Underfull {
                 break;
@@ -101,7 +126,7 @@ impl<T: AllocSource> ReplicaCountPolicy<T> {
         &self,
         src: &NodeDesc,
         target: &NodeDesc,
-        groups: &HashMap<u64, GroupDesc>,
+        group_nodes: &HashMap<u64, HashSet<u64>>,
     ) -> Option<(ReplicaDesc, u64)> {
         // TODO: sort & rank replica
         self.alloc_source
@@ -111,8 +136,8 @@ impl<T: AllocSource> ReplicaCountPolicy<T> {
                 if *g == ROOT_GROUP_ID {
                     return false;
                 }
-                if let Some(group) = groups.get(g) {
-                    if !group.replicas.iter().any(|r| r.node_id == target.id) {
+                if let Some(node_ids) = group_nodes.get(g) {
+                    if !node_ids.contains(&target.id) {
                         return true;
                     }
                 }

--- a/src/server/src/root/allocator/sim_test.rs
+++ b/src/server/src/root/allocator/sim_test.rs
@@ -59,6 +59,7 @@ fn sim_boostrap_join_node_balance() {
             term: 0,
             voted_for: 0,
             role: RaftRole::Leader.into(),
+            node_id: 1,
         }]);
 
         let act = a.compute_group_action().await.unwrap();
@@ -120,6 +121,7 @@ fn sim_boostrap_join_node_balance() {
                 term: 1,
                 voted_for: 0,
                 role: RaftRole::Leader.into(),
+                node_id: 1,
             },
             ReplicaState {
                 replica_id: 2,
@@ -127,6 +129,7 @@ fn sim_boostrap_join_node_balance() {
                 term: 1,
                 voted_for: 0,
                 role: RaftRole::Follower.into(),
+                node_id: 2,
             },
             ReplicaState {
                 replica_id: 3,
@@ -134,6 +137,7 @@ fn sim_boostrap_join_node_balance() {
                 term: 1,
                 voted_for: 0,
                 role: RaftRole::Follower.into(),
+                node_id: 3,
             },
         ]);
         p.display();
@@ -176,6 +180,7 @@ fn sim_boostrap_join_node_balance() {
                             term: 0,
                             voted_for: 0,
                             role,
+                            node_id: n.id,
                         });
                         replica_id_gen += 1;
                     }
@@ -265,6 +270,7 @@ fn sim_boostrap_join_node_balance() {
                             term: 0,
                             voted_for: 0,
                             role,
+                            node_id: n.id,
                         });
                         replica_id_gen += 1;
                     }

--- a/src/server/src/root/allocator/sim_test.rs
+++ b/src/server/src/root/allocator/sim_test.rs
@@ -67,7 +67,7 @@ fn sim_boostrap_join_node_balance() {
         p.display();
 
         println!("2. two node joined");
-        let mut nodes = p.nodes();
+        let mut nodes = p.nodes(false);
         nodes.extend_from_slice(&[
             NodeDesc {
                 id: 2,
@@ -220,7 +220,7 @@ fn sim_boostrap_join_node_balance() {
         }
 
         println!("6. node 4 joined");
-        let mut nodes = p.nodes();
+        let mut nodes = p.nodes(false);
         nodes.extend_from_slice(&[NodeDesc {
             id: 4,
             addr: "".into(),
@@ -441,7 +441,7 @@ impl AllocSource for MockInfoProvider {
         Ok(())
     }
 
-    fn nodes(&self) -> Vec<NodeDesc> {
+    fn nodes(&self, _only_alive: bool) -> Vec<NodeDesc> {
         let nodes = self.nodes.lock().unwrap();
         nodes.to_owned()
     }
@@ -494,7 +494,7 @@ impl MockInfoProvider {
         }
 
         // test only fix node.replica logic
-        let mut nodes = self.nodes();
+        let mut nodes = self.nodes(false);
         for n in nodes.iter_mut() {
             let mut cap = n.capacity.take().unwrap();
             cap.replica_count = node_replicas.get(&n.id).unwrap().len() as u64;
@@ -516,7 +516,7 @@ impl MockInfoProvider {
         let mut replicas = self.replicas.lock().unwrap();
 
         // test only, maintain leader count in node.
-        let mut nodes = self.nodes();
+        let mut nodes = self.nodes(false);
         let groups = self.groups();
         let mut node_leader = HashMap::new();
         for r in &rs {

--- a/src/server/src/root/allocator/source.rs
+++ b/src/server/src/root/allocator/source.rs
@@ -79,8 +79,7 @@ impl AllocSource for SysAllocSource {
     }
 
     fn nodes(&self, only_alive: bool) -> Vec<NodeDesc> {
-        let nodes = self.nodes.lock().unwrap();
-        let mut nodes = nodes.to_owned();
+        let mut nodes = { self.nodes.lock().unwrap().clone() };
         if only_alive {
             nodes = nodes
                 .into_iter()

--- a/src/server/src/root/allocator/source.rs
+++ b/src/server/src/root/allocator/source.rs
@@ -20,13 +20,13 @@ use std::{
 use engula_api::server::v1::*;
 
 use super::RootShared;
-use crate::Result;
+use crate::{root::liveness::Liveness, Result};
 
 #[crate::async_trait]
 pub trait AllocSource {
     async fn refresh_all(&self) -> Result<()>;
 
-    fn nodes(&self) -> Vec<NodeDesc>;
+    fn nodes(&self, only_alive: bool) -> Vec<NodeDesc>;
 
     fn groups(&self) -> HashMap<u64, GroupDesc>;
 
@@ -40,6 +40,7 @@ pub trait AllocSource {
 #[derive(Clone)]
 pub struct SysAllocSource {
     root: Arc<RootShared>,
+    liveness: Arc<Liveness>,
 
     nodes: Arc<Mutex<Vec<NodeDesc>>>,
     groups: Arc<Mutex<GroupInfo>>,
@@ -58,9 +59,10 @@ struct ReplicaInfo {
 }
 
 impl SysAllocSource {
-    pub fn new(root: Arc<RootShared>) -> Self {
+    pub fn new(root: Arc<RootShared>, liveness: Arc<Liveness>) -> Self {
         Self {
             root,
+            liveness,
             nodes: Default::default(),
             groups: Default::default(),
             replicas: Default::default(),
@@ -76,9 +78,16 @@ impl AllocSource for SysAllocSource {
         self.reload_replica_status().await
     }
 
-    fn nodes(&self) -> Vec<NodeDesc> {
+    fn nodes(&self, only_alive: bool) -> Vec<NodeDesc> {
         let nodes = self.nodes.lock().unwrap();
-        nodes.to_owned()
+        let mut nodes = nodes.to_owned();
+        if only_alive {
+            nodes = nodes
+                .into_iter()
+                .filter(|n| !self.liveness.get(&n.id).is_dead())
+                .collect::<Vec<_>>();
+        }
+        nodes
     }
 
     fn groups(&self) -> HashMap<u64, GroupDesc> {

--- a/src/server/src/root/job.rs
+++ b/src/server/src/root/job.rs
@@ -19,6 +19,7 @@ use engula_api::server::v1::{
     *,
 };
 use engula_client::RequestBatchBuilder;
+use futures::future::join_all;
 use tokio::time;
 use tracing::{info, trace, warn};
 
@@ -61,23 +62,25 @@ impl Root {
             });
         }
 
-        let mut hb_futs = Vec::new();
-        for n in nodes {
+        let mut futs = Vec::new();
+        for n in &nodes {
             trace!(node = n.id, target = ?n.addr, "attempt send heartbeat");
             let fut = self.try_send_heartbeat(
                 n.addr.to_owned(),
                 &piggybacks,
                 self.liveness.heartbeat_timeout,
             );
-            hb_futs.push((n.to_owned(), fut));
+            futs.push(fut);
         }
 
-        for (n, fut) in hb_futs {
-            match fut.await {
+        let resps = join_all(futs).await;
+        for (i, resp) in resps.iter().enumerate() {
+            let n = nodes.get(i).unwrap();
+            match resp {
                 Ok(res) => {
                     self.liveness.renew(n.id);
-                    for resp in res.piggybacks {
-                        match resp.info.unwrap() {
+                    for resp in &res.piggybacks {
+                        match resp.info.as_ref().unwrap() {
                             piggyback_response::Info::SyncRoot(_) => {}
                             piggyback_response::Info::CollectStats(resp) => {
                                 self.handle_collect_stats(&schema, resp, n.id).await?
@@ -115,10 +118,10 @@ impl Root {
     async fn handle_collect_stats(
         &self,
         schema: &Schema,
-        resp: CollectStatsResponse,
+        resp: &CollectStatsResponse,
         node_id: u64,
     ) -> Result<()> {
-        if let Some(ns) = resp.node_stats {
+        if let Some(ns) = &resp.node_stats {
             if let Some(mut node) = schema.get_node(node_id).await? {
                 let new_group_count = ns.group_count as u64;
                 let new_leader_count = ns.leader_count as u64;
@@ -143,7 +146,7 @@ impl Root {
     async fn handle_group_detail(
         &self,
         schema: &Schema,
-        resp: CollectGroupDetailResponse,
+        resp: &CollectGroupDetailResponse,
     ) -> Result<()> {
         let mut update_events = Vec::new();
 

--- a/src/server/src/root/liveness.rs
+++ b/src/server/src/root/liveness.rs
@@ -1,0 +1,103 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    collections::{hash_map, HashMap},
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use crate::Config;
+
+#[derive(Clone)]
+pub struct NodeLiveness {
+    expiration: u128,
+}
+
+impl NodeLiveness {
+    pub fn is_dead(&self) -> bool {
+        const DEAD_THRESHOLD: u128 = Duration::from_secs(60).as_millis();
+        self.expiration + DEAD_THRESHOLD < current_timestamp()
+    }
+
+    #[allow(dead_code)]
+    pub fn is_alive(&self) -> bool {
+        self.expiration > current_timestamp()
+    }
+}
+
+#[derive(Clone)]
+pub struct Liveness {
+    liveness_threshold: Duration,
+    pub heartbeat_timeout: Duration,
+
+    nodes: Arc<Mutex<HashMap<u64, NodeLiveness>>>,
+}
+
+impl Liveness {
+    pub fn new(cfg: Config) -> Self {
+        const RAFT_ELECTION_TIMEOUT_MULTIPLIER: u64 = 3;
+        const LIVENESS_FRAC: f64 = 0.5;
+
+        let liveness_threshold = Duration::from_millis(
+            cfg.raft.election_tick as u64
+                * cfg.raft.tick_interval_ms
+                * RAFT_ELECTION_TIMEOUT_MULTIPLIER,
+        );
+        let heartbeat_timeout =
+            Duration::from_millis((liveness_threshold.as_millis() as f64 * LIVENESS_FRAC) as u64);
+        Self {
+            liveness_threshold,
+            heartbeat_timeout,
+            nodes: Default::default(),
+        }
+    }
+
+    pub fn get(&self, node: &u64) -> NodeLiveness {
+        let nodes = self.nodes.lock().unwrap();
+        nodes.get(node).cloned().unwrap_or_else(|| NodeLiveness {
+            expiration: self.new_expiration(),
+        })
+    }
+
+    pub fn renew(&self, node_id: u64) {
+        let mut nodes = self.nodes.lock().unwrap();
+        let entry = nodes.entry(node_id);
+        match entry {
+            hash_map::Entry::Occupied(mut ent) => {
+                let renew = self.new_expiration();
+                let ent = ent.get_mut();
+                if ent.expiration < renew {
+                    ent.expiration = renew
+                }
+            }
+            hash_map::Entry::Vacant(ent) => {
+                ent.insert(NodeLiveness {
+                    expiration: self.new_expiration(),
+                });
+            }
+        }
+    }
+
+    fn new_expiration(&self) -> u128 {
+        current_timestamp() + self.liveness_threshold.as_millis()
+    }
+}
+
+fn current_timestamp() -> u128 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let start = SystemTime::now();
+    let since_the_epoch = start.duration_since(UNIX_EPOCH).unwrap();
+    since_the_epoch.as_millis()
+}

--- a/src/server/src/root/liveness.rs
+++ b/src/server/src/root/liveness.rs
@@ -46,7 +46,7 @@ pub struct Liveness {
 
 impl Liveness {
     pub fn new(cfg: Config) -> Self {
-        const RAFT_ELECTION_TIMEOUT_MULTIPLIER: u64 = 3;
+        const RAFT_ELECTION_TIMEOUT_MULTIPLIER: u64 = 2;
         const LIVENESS_FRAC: f64 = 0.5;
 
         // ensure liveness_threshold >>> raft_election_timeout?

--- a/src/server/src/root/mod.rs
+++ b/src/server/src/root/mod.rs
@@ -14,6 +14,7 @@
 
 mod allocator;
 mod job;
+mod liveness;
 mod schema;
 mod store;
 mod watch;
@@ -53,6 +54,7 @@ use crate::{
 pub struct Root {
     shared: Arc<RootShared>,
     alloc: allocator::Allocator<SysAllocSource>,
+    liveness: Arc<liveness::Liveness>,
 }
 
 pub struct RootShared {
@@ -86,9 +88,14 @@ impl Root {
             node_ident: node_ident.to_owned(),
             watcher_hub: Default::default(),
         });
-        let info = Arc::new(SysAllocSource::new(shared.clone()));
+        let liveness = Arc::new(liveness::Liveness::new(cfg.to_owned()));
+        let info = Arc::new(SysAllocSource::new(shared.clone(), liveness.to_owned()));
         let alloc = allocator::Allocator::new(info, cfg.allocator);
-        Self { alloc, shared }
+        Self {
+            alloc,
+            shared,
+            liveness,
+        }
     }
 
     pub fn is_root(&self) -> bool {


### PR DESCRIPTION
1. avoid moving or advising replica to the node that already contains replica(even if the one that does not include in group_desc)

ref #856, this can relieve the recreating replica problem

3.  avoid useless drop root leader

turn off a normal node shouldn't observe drop leader log in root leader node.

4. add rough root liveness

closes #861, we can observe allocate stop trying to reallocate replica or transfer leader to offline-node after 1 min.

5. send heartbeat parallel

but slow reconcile still can cause inaccurate heartbeat interval, but it can be solve in next PR(add scheduler to async execute task)