### PR TITLE
root: fix wrong group inital replica count

### DIFF
--- a/src/server/src/root/allocator/mod.rs
+++ b/src/server/src/root/allocator/mod.rs
@@ -128,6 +128,11 @@ impl<T: AllocSource> Allocator<T> {
             config,
         }
     }
+
+    pub fn replicas_per_group(&self) -> usize {
+        self.config.replicas_per_group
+    }
+
     /// Compute group change action.
     pub async fn compute_group_action(&self) -> Result<GroupAction> {
         if !self.config.enable_group_balance {

--- a/src/server/src/root/schedule.rs
+++ b/src/server/src/root/schedule.rs
@@ -110,7 +110,7 @@ impl ReconcileScheduler {
             for _ in 0..cnt {
                 self.setup_task(ReconcileTask {
                     task: Some(reconcile_task::Task::CreateGroup(CreateGroupTask {
-                        request_replica_cnt: cnt as u64,
+                        request_replica_cnt: self.ctx.alloc.replicas_per_group() as u64,
                         step: CreateGroupTaskStep::GroupInit as i32,
                         ..Default::default()
                     })),


### PR DESCRIPTION
Fix a mistake introduced by previous refactor #888

For example, if we want to allocate 16 groups, the last group task will try to create wrong 16 replicas