### PR TITLE
*: disable tracing colorized output if not tty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,6 +494,7 @@ dependencies = [
 name = "engula"
 version = "0.4.0"
 dependencies = [
+ "atty",
  "clap",
  "config",
  "engula-server",

--- a/src/bin/Cargo.toml
+++ b/src/bin/Cargo.toml
@@ -17,3 +17,4 @@ config = { version = "0.13.1", features = ["toml"] }
 num_cpus = "1.13.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
+atty = "0.2.14"

--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -81,7 +81,9 @@ impl StartCommand {
 }
 
 fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_ansi(atty::is(atty::Stream::Stderr))
+        .init();
 
     let cmd = Command::parse();
     cmd.run()


### PR DESCRIPTION
Tracing's default output is colorized tokio-rs/tracing#1160, it makes us hard to grep structured log(e.g. `fgrep 'group=xx' d1.log` get nothing)

It's better to turn it off when we redirect stdout/stderr to file(usually both, `RUST_LOG=INFO cargo run start --init --db d1 &> d1.log`).
