### PR TITLE
root: support access /admin/metadata http api in not-root node

### DIFF
--- a/src/server/src/service/admin/health.rs
+++ b/src/server/src/service/admin/health.rs
@@ -18,7 +18,7 @@ pub(super) struct HealthHandle;
 
 #[crate::async_trait]
 impl super::service::HttpHandle for HealthHandle {
-    async fn call(&self) -> crate::Result<http::Response<String>> {
+    async fn call(&self, _: &str) -> crate::Result<http::Response<String>> {
         Ok(http::Response::builder()
             .status(http::StatusCode::OK)
             .body("Ok\n".to_owned())

--- a/src/server/src/service/admin/metrics.rs
+++ b/src/server/src/service/admin/metrics.rs
@@ -28,7 +28,7 @@ pub(super) struct MetricsHandle;
 
 #[crate::async_trait]
 impl super::service::HttpHandle for MetricsHandle {
-    async fn call(&self) -> crate::Result<http::Response<String>> {
+    async fn call(&self, _: &str) -> crate::Result<http::Response<String>> {
         METRICS_RPC_REQUESTS_TOTAL.inc();
 
         let encoder = TextEncoder::new();

--- a/src/server/src/service/admin/mod.rs
+++ b/src/server/src/service/admin/mod.rs
@@ -24,10 +24,7 @@ use crate::Server;
 pub fn make_admin_service(server: Server) -> AdminService {
     let router = Router::empty()
         .route("/metrics", self::metrics::MetricsHandle)
-        .route(
-            "/metadata",
-            self::metadata::MetadataHandle::new(server.root),
-        )
+        .route("/metadata", self::metadata::MetadataHandle::new(server))
         .route("/health", self::health::HealthHandle);
     let api = Router::nest("/admin", router);
     AdminService::new(api)

--- a/src/server/src/service/admin/service.rs
+++ b/src/server/src/service/admin/service.rs
@@ -26,7 +26,7 @@ use tonic::{
 
 #[crate::async_trait]
 pub(super) trait HttpHandle: Send + Sync {
-    async fn call(&self) -> crate::Result<http::Response<String>>;
+    async fn call(&self, path: &str) -> crate::Result<http::Response<String>>;
 }
 
 pub(super) struct Router {
@@ -123,7 +123,7 @@ impl Router {
             }
         };
 
-        let resp = match handle.call().await {
+        let resp = match handle.call(&path).await {
             Ok(resp) => resp.map(boxed),
             Err(e) => http::Response::builder()
                 .status(http::StatusCode::INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
redirect the client to root when the access node is not root.

this can test with `curl -L` and make easier to test when root change