### PR TITLE
root: fix unaccess success node be judged as online

### DIFF
--- a/src/server/src/root/job.rs
+++ b/src/server/src/root/job.rs
@@ -91,6 +91,7 @@ impl Root {
                     }
                 }
                 Err(err) => {
+                    self.liveness.init_node_if_first_seen(n.id);
                     warn!(node = n.id, target = ?n.addr, err = ?err, "send heartbeat error");
                 }
             }

--- a/src/server/src/root/liveness.rs
+++ b/src/server/src/root/liveness.rs
@@ -99,6 +99,20 @@ impl Liveness {
         }
     }
 
+    pub fn init_node_if_first_seen(&self, node_id: u64) {
+        // Give `liveness_threshold` time window to retry before mark as offline.
+        let mut nodes = self.nodes.lock().unwrap();
+        if let hash_map::Entry::Vacant(ent) = nodes.entry(node_id) {
+            ent.insert(NodeLiveness {
+                expiration: self.new_expiration(),
+            });
+        }
+    }
+
+    pub fn reset(&self) {
+        self.nodes.lock().unwrap().clear();
+    }
+
     fn new_expiration(&self) -> u128 {
         current_timestamp() + self.liveness_threshold.as_millis()
     }

--- a/src/server/src/root/mod.rs
+++ b/src/server/src/root/mod.rs
@@ -217,6 +217,9 @@ impl Root {
 
         // After that, RootCore needs to be set to None before returning.
         {
+
+            self.liveness.reset();
+
             let mut core = self.shared.core.lock().unwrap();
             *core = None;
         }


### PR DESCRIPTION
closes #905

just add init liveness record when heartbeat fail and no exist liveness record, the node will be judged as offline after liveness-threshold passed