### PR TITLE
root: add root process metrics

### DIFF
--- a/src/server/src/root/job.rs
+++ b/src/server/src/root/job.rs
@@ -202,11 +202,11 @@ impl Root {
 
         let mut changed_group_states = HashSet::new();
         for state in &resp.replica_states {
-            if let Some(ex) = schema
+            if let Some(pre_state) = schema
                 .get_replica_state(state.group_id, state.replica_id)
                 .await?
             {
-                if state.term <= ex.term {
+                if state.term < pre_state.term {
                     continue;
                 }
             }

--- a/src/server/src/root/job.rs
+++ b/src/server/src/root/job.rs
@@ -23,7 +23,10 @@ use tokio::time::Instant;
 use tracing::{info, trace, warn};
 
 use super::{HeartbeatTask, Root, Schema};
-use crate::{root::schema::ReplicaNodes, Result};
+use crate::{
+    root::{metrics, schema::ReplicaNodes},
+    Result,
+};
 
 impl Root {
     pub async fn send_heartbeat(&self, schema: Arc<Schema>, tasks: &[HeartbeatTask]) -> Result<()> {
@@ -67,18 +70,22 @@ impl Root {
             });
         }
 
-        let mut futs = Vec::new();
-        for n in &nodes {
-            trace!(node = n.id, target = ?n.addr, "attempt send heartbeat");
-            let fut = self.try_send_heartbeat(
-                n.addr.to_owned(),
-                &piggybacks,
-                Duration::from_secs(self.cfg.heartbeat_timeout_sec),
-            );
-            futs.push(fut);
-        }
+        let resps = {
+            let _timer = metrics::HEARTBEAT_NODES_RPC_DURATION_SECONDS.start_timer();
+            metrics::HEARTBEAT_NODES_BATCH_SIZE.observe(nodes.len() as f64);
+            let mut futs = Vec::new();
+            for n in &nodes {
+                trace!(node = n.id, target = ?n.addr, "attempt send heartbeat");
+                let fut = self.try_send_heartbeat(
+                    n.addr.to_owned(),
+                    &piggybacks,
+                    Duration::from_secs(self.cfg.heartbeat_timeout_sec),
+                );
+                futs.push(fut);
+            }
+            join_all(futs).await
+        };
 
-        let resps = join_all(futs).await;
         let last_heartbeat = Instant::now();
         let mut heartbeat_tasks = Vec::new();
         for (i, resp) in resps.iter().enumerate() {
@@ -100,6 +107,9 @@ impl Root {
                     }
                 }
                 Err(err) => {
+                    super::metrics::HEARTBEAT_TASK_FAIL_TOTAL
+                        .with_label_values(&[&n.id.to_string()])
+                        .inc();
                     self.liveness.init_node_if_first_seen(n.id);
                     warn!(node = n.id, target = ?n.addr, err = ?err, "send heartbeat error");
                 }
@@ -140,10 +150,13 @@ impl Root {
     ) -> Result<()> {
         if let Some(ns) = &resp.node_stats {
             if let Some(mut node) = schema.get_node(node_id).await? {
+                let _timer =
+                    super::metrics::HEARTBEAT_HANDLE_NODE_STATS_DURATION_SECONDS.start_timer();
                 let new_group_count = ns.group_count as u64;
                 let new_leader_count = ns.leader_count as u64;
                 let mut cap = node.capacity.take().unwrap();
                 if new_group_count != cap.replica_count || new_leader_count != cap.leader_count {
+                    super::metrics::HEARTBEAT_UPDATE_NODE_STATS_TOTAL.inc();
                     cap.replica_count = new_group_count;
                     cap.leader_count = new_leader_count;
                     info!(
@@ -165,8 +178,8 @@ impl Root {
         schema: &Schema,
         resp: &CollectGroupDetailResponse,
     ) -> Result<()> {
+        let _timer = super::metrics::HEARTBEAT_HANDLE_GROUP_DETAIL_DURATION_SECONDS.start_timer();
         let mut update_events = Vec::new();
-
         for desc in &resp.group_descs {
             if let Some(ex) = schema.get_group(desc.id).await? {
                 if desc.epoch <= ex.epoch {
@@ -176,6 +189,7 @@ impl Root {
             schema
                 .update_group_replica(Some(desc.to_owned()), None)
                 .await?;
+            metrics::ROOT_UPDATE_GROUP_DESC_TOTAL.heartbeat.inc();
             info!(
                 group = desc.id,
                 desc = ?desc,
@@ -199,6 +213,7 @@ impl Root {
             schema
                 .update_group_replica(None, Some(state.to_owned()))
                 .await?;
+            metrics::ROOT_UPDATE_REPLICA_STATE_TOTAL.heartbeat.inc();
             info!(
                 group = state.group_id,
                 replica = state.replica_id,

--- a/src/server/src/root/metrics.rs
+++ b/src/server/src/root/metrics.rs
@@ -18,8 +18,8 @@ use prometheus_static_metric::make_static_metric;
 
 // root status.
 lazy_static! {
-    pub static ref LEADER_STATE: IntGauge = register_int_gauge!(
-        "root_service_node_as_leader_gauge",
+    pub static ref LEADER_STATE_INFO: IntGauge = register_int_gauge!(
+        "root_service_node_as_leader_info",
         "the node as root leader count"
     )
     .unwrap();
@@ -33,8 +33,8 @@ lazy_static! {
         "the duration of bootstrap root service"
     )
     .unwrap();
-    pub static ref BOOTSTRAP_FAIL_COUNT: IntCounter = register_int_counter!(
-        "root_boostrap_fail_count",
+    pub static ref BOOTSTRAP_FAIL_TOTAL: IntCounter = register_int_counter!(
+        "root_boostrap_fail_total",
         "the count of boostrap root fail"
     )
     .unwrap();
@@ -116,49 +116,52 @@ lazy_static! {
     .unwrap();
     pub static ref RECONCILE_HANDLE_TASK_TOTAL: ReconcileScheduleHandleTaskTotal =
         ReconcileScheduleHandleTaskTotal::from(&RECONCILE_HANDLE_TASK_TOTAL_VEC);
-    pub static ref RECONCILE_CHECK_DURATION: Histogram = register_histogram!(
-        "root_reconcile_scheduler_check_task_duration",
+    pub static ref RECONCILE_CHECK_DURATION_SECONDS: Histogram = register_histogram!(
+        "root_reconcile_scheduler_check_task_duration_seconds",
         "the duration of scheduler check and prepare tasks",
     )
     .unwrap();
-    pub static ref RECONCILE_HANDL_TASK_DURATION_VEC: HistogramVec = register_histogram_vec!(
-        "root_reconcile_scheduler_task_handle_duration",
-        "the total handle duration of root reconcile scheduler",
-        &["type"]
-    )
-    .unwrap();
-    pub static ref RECONCILE_HANDL_TASK_DURATION: ReconcileScheduleHandleTaskDuration =
-        ReconcileScheduleHandleTaskDuration::from(&RECONCILE_HANDL_TASK_DURATION_VEC);
-    pub static ref RECONCILE_CREATE_GROUP_STEP_DURATION_VEC: HistogramVec =
+    pub static ref RECONCILE_HANDL_TASK_DURATION_SECONDS_VEC: HistogramVec =
         register_histogram_vec!(
-            "root_reconcile_scheduler_create_group_step_duration",
+            "root_reconcile_scheduler_task_handle_duration_seconds",
+            "the total handle duration of root reconcile scheduler",
+            &["type"]
+        )
+        .unwrap();
+    pub static ref RECONCILE_HANDL_TASK_DURATION_SECONDS: ReconcileScheduleHandleTaskDuration =
+        ReconcileScheduleHandleTaskDuration::from(&RECONCILE_HANDL_TASK_DURATION_SECONDS_VEC);
+    pub static ref RECONCILE_CREATE_GROUP_STEP_DURATION_SECONDS_VEC: HistogramVec =
+        register_histogram_vec!(
+            "root_reconcile_scheduler_create_group_step_duration_seconds",
             "the step create_group handle duration of root reconcile scheduler",
             &["type"]
         )
         .unwrap();
-    pub static ref RECONCILE_CREATE_GROUP_STEP_DURATION: ReconcileScheduleCreateGroupStepDuration =
-        ReconcileScheduleCreateGroupStepDuration::from(&RECONCILE_CREATE_GROUP_STEP_DURATION_VEC);
-    pub static ref RECONCILE_REALLOCATE_REPLICA_STEP_DURATION_VEC: HistogramVec =
+    pub static ref RECONCILE_CREATE_GROUP_STEP_DURATION_SECONDS: ReconcileScheduleCreateGroupStepDuration =
+        ReconcileScheduleCreateGroupStepDuration::from(
+            &RECONCILE_CREATE_GROUP_STEP_DURATION_SECONDS_VEC
+        );
+    pub static ref RECONCILE_REALLOCATE_REPLICA_STEP_DURATION_SECONDS_VEC: HistogramVec =
         register_histogram_vec!(
-            "root_reconcile_scheduler_reallocate_replica_step_duration",
+            "root_reconcile_scheduler_reallocate_replica_step_duration_seconds",
             "the step reallocate replica handle duration of root reconcile scheduler",
             &["type"]
         )
         .unwrap();
-    pub static ref RECONCILE_REALLOCATE_REPLICA_STEP_DURATION: ReconcileScheduleReallocateReplicaStepDuration =
+    pub static ref RECONCILE_REALLOCATE_REPLICA_STEP_DURATION_SECONDS: ReconcileScheduleReallocateReplicaStepDuration =
         ReconcileScheduleReallocateReplicaStepDuration::from(
-            &RECONCILE_REALLOCATE_REPLICA_STEP_DURATION_VEC
+            &RECONCILE_REALLOCATE_REPLICA_STEP_DURATION_SECONDS_VEC
         );
-    pub static ref RECONCILE_CREATE_COLLECTION_STEP_DURATION_VEC: HistogramVec =
+    pub static ref RECONCILE_CREATE_COLLECTION_STEP_DURATION_SECONDS_VEC: HistogramVec =
         register_histogram_vec!(
-            "root_reconcile_scheduler_create_collection_step_duration",
+            "root_reconcile_scheduler_create_collection_step_duration_seconds",
             "the step create_ collection shards handle duration of root reconcile scheduler",
             &["type"]
         )
         .unwrap();
     pub static ref RECONCILE_CREATE_COLLECTION_STEP_DURATION: ReconcileScheduleCreateCollectionStepDuration =
         ReconcileScheduleCreateCollectionStepDuration::from(
-            &RECONCILE_CREATE_COLLECTION_STEP_DURATION_VEC
+            &RECONCILE_CREATE_COLLECTION_STEP_DURATION_SECONDS_VEC
         );
     pub static ref RECONCILE_RETRYL_TASK_TOTAL_VEC: IntCounterVec = register_int_counter_vec!(
         "root_reconcile_scheduler_task_retry_total",

--- a/src/server/src/root/metrics.rs
+++ b/src/server/src/root/metrics.rs
@@ -1,0 +1,264 @@
+// Copyright 2022 The Engula Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use lazy_static::lazy_static;
+use prometheus::*;
+use prometheus_static_metric::make_static_metric;
+
+// root status.
+lazy_static! {
+    pub static ref LEADER_STATE: IntGauge = register_int_gauge!(
+        "root_service_node_as_leader_gauge",
+        "the node as root leader count"
+    )
+    .unwrap();
+}
+
+// bootstrap root.
+
+lazy_static! {
+    pub static ref BOOTSTRAP_DURATION_SECONDS: Histogram = register_histogram!(
+        "root_bootstrap_duration_seconds",
+        "the duration of bootstrap root service"
+    )
+    .unwrap();
+    pub static ref BOOTSTRAP_FAIL_COUNT: IntCounter = register_int_counter!(
+        "root_boostrap_fail_count",
+        "the count of boostrap root fail"
+    )
+    .unwrap();
+}
+
+// reconcile.
+
+make_static_metric! {
+    pub struct ReconcileScheduleHandleTaskTotal: IntCounter {
+        "type" => {
+            create_group,
+            reallocate_replica,
+            migrate_shard,
+            transfer_leader,
+            create_collection_shards,
+            shed_group_leaders,
+            shed_root_leader,
+        }
+    }
+    pub struct ReconcileScheduleHandleTaskDuration: Histogram {
+        "type" => {
+            create_group,
+            reallocate_replica,
+            migrate_shard,
+            transfer_leader,
+            create_collection_shards,
+            shed_group_leaders,
+            shed_root_leader,
+        }
+    }
+    pub struct ReconcileScheduleCreateGroupStepDuration: Histogram {
+        "type" => {
+            init,
+            create,
+            rollback,
+            finish,
+        }
+    }
+    pub struct ReconcileScheduleReallocateReplicaStepDuration: Histogram {
+        "type" => {
+            create_dest_replica,
+            add_dest_learner,
+            replica_dest_voter,
+            shed_src_leader,
+            remove_src_membership,
+            remove_src_replica,
+            finish,
+        }
+    }
+    pub struct ReconcileScheduleCreateCollectionStepDuration: Histogram {
+        "type" => {
+            create,
+            rollback,
+        }
+    }
+}
+
+lazy_static! {
+    pub static ref RECONCILE_STEP_DURATION_SECONDS: Histogram = register_histogram!(
+        "root_reconcile_step_duration_seconds",
+        "the duration of one reconcile step"
+    )
+    .unwrap();
+    pub static ref RECONCILE_ALREADY_BALANCED_TOTAL: Counter = register_counter!(
+        "root_reconcile_already_balanced_total",
+        "the count of observe cluster is already balanced in root reconcile task"
+    )
+    .unwrap();
+    pub static ref RECONCILE_SCHEDULER_TASK_QUEUE_SIZE: Histogram = register_histogram!(
+        "root_reconcile_scheduler_task_queue_size",
+        "the size of scheduler task queue size during each reconcile step"
+    )
+    .unwrap();
+    pub static ref RECONCILE_HANDLE_TASK_TOTAL_VEC: IntCounterVec = register_int_counter_vec!(
+        "root_reconcile_scheduler_task_handle_total",
+        "The total handle count of root reconcile scheduler",
+        &["type"]
+    )
+    .unwrap();
+    pub static ref RECONCILE_HANDLE_TASK_TOTAL: ReconcileScheduleHandleTaskTotal =
+        ReconcileScheduleHandleTaskTotal::from(&RECONCILE_HANDLE_TASK_TOTAL_VEC);
+    pub static ref RECONCILE_CHECK_DURATION: Histogram = register_histogram!(
+        "root_reconcile_scheduler_check_task_duration",
+        "the duration of scheduler check and prepare tasks",
+    )
+    .unwrap();
+    pub static ref RECONCILE_HANDL_TASK_DURATION_VEC: HistogramVec = register_histogram_vec!(
+        "root_reconcile_scheduler_task_handle_duration",
+        "the total handle duration of root reconcile scheduler",
+        &["type"]
+    )
+    .unwrap();
+    pub static ref RECONCILE_HANDL_TASK_DURATION: ReconcileScheduleHandleTaskDuration =
+        ReconcileScheduleHandleTaskDuration::from(&RECONCILE_HANDL_TASK_DURATION_VEC);
+    pub static ref RECONCILE_CREATE_GROUP_STEP_DURATION_VEC: HistogramVec =
+        register_histogram_vec!(
+            "root_reconcile_scheduler_create_group_step_duration",
+            "the step create_group handle duration of root reconcile scheduler",
+            &["type"]
+        )
+        .unwrap();
+    pub static ref RECONCILE_CREATE_GROUP_STEP_DURATION: ReconcileScheduleCreateGroupStepDuration =
+        ReconcileScheduleCreateGroupStepDuration::from(&RECONCILE_CREATE_GROUP_STEP_DURATION_VEC);
+    pub static ref RECONCILE_REALLOCATE_REPLICA_STEP_DURATION_VEC: HistogramVec =
+        register_histogram_vec!(
+            "root_reconcile_scheduler_reallocate_replica_step_duration",
+            "the step reallocate replica handle duration of root reconcile scheduler",
+            &["type"]
+        )
+        .unwrap();
+    pub static ref RECONCILE_REALLOCATE_REPLICA_STEP_DURATION: ReconcileScheduleReallocateReplicaStepDuration =
+        ReconcileScheduleReallocateReplicaStepDuration::from(
+            &RECONCILE_REALLOCATE_REPLICA_STEP_DURATION_VEC
+        );
+    pub static ref RECONCILE_CREATE_COLLECTION_STEP_DURATION_VEC: HistogramVec =
+        register_histogram_vec!(
+            "root_reconcile_scheduler_create_collection_step_duration",
+            "the step create_ collection shards handle duration of root reconcile scheduler",
+            &["type"]
+        )
+        .unwrap();
+    pub static ref RECONCILE_CREATE_COLLECTION_STEP_DURATION: ReconcileScheduleCreateCollectionStepDuration =
+        ReconcileScheduleCreateCollectionStepDuration::from(
+            &RECONCILE_CREATE_COLLECTION_STEP_DURATION_VEC
+        );
+    pub static ref RECONCILE_RETRYL_TASK_TOTAL_VEC: IntCounterVec = register_int_counter_vec!(
+        "root_reconcile_scheduler_task_retry_total",
+        "The total retry count of root reconcile scheduler",
+        &["type"]
+    )
+    .unwrap();
+    pub static ref RECONCILE_RETRYL_TASK_TOTAL: ReconcileScheduleHandleTaskTotal =
+        ReconcileScheduleHandleTaskTotal::from(&RECONCILE_RETRYL_TASK_TOTAL_VEC);
+}
+
+// hearbeat & report
+
+make_static_metric! {
+    pub struct UpdateGroupDesc: IntCounter {
+        "type" => {
+            report,
+            heartbeat,
+        }
+    }
+    pub struct UpdateReplicaState: IntCounter {
+        "type" => {
+            report,
+            heartbeat,
+        }
+    }
+}
+
+lazy_static! {
+    pub static ref HEARTBEAT_STEP_DURATION_SECONDS: Histogram = register_histogram!(
+        "root_heartbeat_step_duration_seconds",
+        "the duration of one heartbeat step"
+    )
+    .unwrap();
+    pub static ref HEARTBEAT_TASK_QUEUE_SIZE: Histogram = register_histogram!(
+        "root_heartbeat_task_queue_size",
+        "the size of heartbeat task queue size during each heartbeat step observered"
+    )
+    .unwrap();
+    pub static ref HEARTBEAT_TASK_FAIL_TOTAL: IntCounterVec = register_int_counter_vec!(
+        "root_heartbeat_fail_total",
+        "the count of heartbeat fail",
+        &["node"]
+    )
+    .unwrap();
+    pub static ref HEARTBEAT_RESCHEDULE_EARLY_INTERVAL_SECONDS: Histogram = register_histogram!(
+        "root_heartbeat_reschedule_early_interval_seconds",
+        "the interval of heartbeat be rescheduled early"
+    )
+    .unwrap();
+    pub static ref HEARTBEAT_NODES_RPC_DURATION_SECONDS: Histogram = register_histogram!(
+        "root_heartbeat_rpc_nodes_duration_seconds",
+        "the duration of rpc heartbeat multiple nodes togather"
+    )
+    .unwrap();
+    pub static ref HEARTBEAT_NODES_BATCH_SIZE: Histogram = register_histogram!(
+        "root_heartbeat_nodes_batch_size",
+        "the number of nodes be sent in one heartbeat step"
+    )
+    .unwrap();
+    pub static ref HEARTBEAT_HANDLE_GROUP_DETAIL_DURATION_SECONDS: Histogram = register_histogram!(
+        "root_heartbeat_handle_group_detail_seconds",
+        "the duration of handle update group detail after recieve heartbeat response"
+    )
+    .unwrap();
+    pub static ref HEARTBEAT_HANDLE_NODE_STATS_DURATION_SECONDS: Histogram = register_histogram!(
+        "root_heartbeat_handle_node_stats_seconds",
+        "the duration of handle update stats after recieve heartbeat response"
+    )
+    .unwrap();
+    pub static ref HEARTBEAT_UPDATE_NODE_STATS_TOTAL: IntCounter = register_int_counter!(
+        "root_heartbeat_update_node_stats_total",
+        "the count of real update node stats after recieve heartbeat response",
+    )
+    .unwrap();
+    pub static ref ROOT_UPDATE_GROUP_DESC_TOTAL_VEC: IntCounterVec = register_int_counter_vec!(
+        "root_update_group_desc_total",
+        "The count of update group_desc",
+        &["type"]
+    )
+    .unwrap();
+    pub static ref ROOT_UPDATE_GROUP_DESC_TOTAL: UpdateGroupDesc =
+        UpdateGroupDesc::from(&ROOT_UPDATE_GROUP_DESC_TOTAL_VEC);
+    pub static ref ROOT_UPDATE_REPLICA_STATE_TOTAL_VEC: IntCounterVec = register_int_counter_vec!(
+        "root_update_replica_state_total",
+        "The count of update replica_state",
+        &["type"]
+    )
+    .unwrap();
+    pub static ref ROOT_UPDATE_REPLICA_STATE_TOTAL: UpdateReplicaState =
+        UpdateReplicaState::from(&ROOT_UPDATE_REPLICA_STATE_TOTAL_VEC);
+}
+
+// watch
+lazy_static! {
+    pub static ref WATCH_TABLE_SIZE: IntGauge =
+        register_int_gauge!("root_watch_table_size", "the count of the root watcher").unwrap();
+    pub static ref WATCH_NOTIFY_DURATION_SECONDS: Histogram = register_histogram!(
+        "root_watch_notify_duration_seconds",
+        "the duration of watch notify(mainly wait watch lock)",
+    )
+    .unwrap();
+}

--- a/src/server/src/root/mod.rs
+++ b/src/server/src/root/mod.rs
@@ -15,6 +15,7 @@
 mod allocator;
 mod job;
 mod liveness;
+mod metrics;
 mod schedule;
 mod schema;
 mod store;
@@ -195,8 +196,10 @@ impl Root {
     async fn run_heartbeat(&self) -> ! {
         loop {
             if let Ok(schema) = self.schema() {
+                let _timer = metrics::HEARTBEAT_STEP_DURATION_SECONDS.start_timer();
                 let nodes = self.heartbeat_queue.try_poll().await;
                 if !nodes.is_empty() {
+                    metrics::HEARTBEAT_TASK_QUEUE_SIZE.observe(nodes.len() as f64);
                     if let Err(err) = self.send_heartbeat(schema.to_owned(), &nodes).await {
                         warn!(err = ?err, "send heartbeat meet error");
                     }
@@ -222,6 +225,7 @@ impl Root {
                 .try_bootstrap_root(local_addr, self.shared.node_ident.cluster_id.clone())
                 .await
             {
+                metrics::BOOTSTRAP_FAIL_COUNT.inc();
                 error!(err = ?err, "boostrap error");
                 panic!("boostrap cluster failure")
             }
@@ -234,6 +238,7 @@ impl Root {
                 schema: Arc::new(schema.to_owned()),
             });
         }
+        self::metrics::LEADER_STATE.set(1);
 
         self.heartbeat_queue.enable(true).await;
 
@@ -270,6 +275,8 @@ impl Root {
             let mut core = self.shared.core.lock().unwrap();
             *core = None;
         }
+
+        self::metrics::LEADER_STATE.set(0);
 
         Ok(())
     }
@@ -758,29 +765,48 @@ impl Root {
         let mut update_events = Vec::new();
         let mut changed_group_states = Vec::new();
         for u in updates {
-            if u.group_desc.is_some() {
-                // TODO: check & handle remove replicas from group
-            }
+            let group_desc = if let Some(update_group) = &u.group_desc {
+                match schema.get_group(u.group_id).await? {
+                    Some(pre_group) if pre_group.epoch >= update_group.epoch => None,
+                    _ => u.group_desc,
+                }
+            } else {
+                None
+            };
+
+            let replica_state = if let Some(update_replica_state) = &u.replica_state {
+                match schema
+                    .get_replica_state(u.group_id, update_replica_state.replica_id)
+                    .await?
+                {
+                    Some(pre_rs) if pre_rs.term >= update_replica_state.term => None,
+                    _ => u.replica_state,
+                }
+            } else {
+                None
+            };
             schema
-                .update_group_replica(u.group_desc.to_owned(), u.replica_state.to_owned())
+                .update_group_replica(group_desc.to_owned(), replica_state.to_owned())
                 .await?;
-            if let Some(desc) = u.group_desc {
+            if let Some(desc) = group_desc {
                 info!(
                     group = desc.id,
                     desc = ?desc,
                     "update group_desc from node report"
                 );
+                metrics::ROOT_UPDATE_GROUP_DESC_TOTAL.report.inc();
                 update_events.push(UpdateEvent {
                     event: Some(update_event::Event::Group(desc)),
                 })
             }
-            if let Some(state) = u.replica_state {
+            if let Some(state) = replica_state {
                 info!(
                     group = state.group_id,
                     replica = state.replica_id,
                     state = ?state,
                     "update replica_state from node report"
                 );
+                metrics::ROOT_UPDATE_REPLICA_STATE_TOTAL.report.inc();
                 changed_group_states.push(state.group_id);
             }
         }
@@ -905,7 +931,9 @@ impl HeartbeatQueue {
             if let Some((scheduled_key, old_when)) =
                 core.node_scheduled.get(&node).map(ToOwned::to_owned)
             {
-                if when <= old_when {
+                if when < old_when {
+                    metrics::HEARTBEAT_RESCHEDULE_EARLY_INTERVAL_SECONDS
+                        .observe(old_when.saturating_duration_since(when).as_secs_f64());
                     core.delay.reset_at(&scheduled_key, when);
                     core.node_scheduled.insert(node, (scheduled_key, when));
                     trace!(node=node, when=?when, "update next heartbeat");

--- a/src/server/src/root/mod.rs
+++ b/src/server/src/root/mod.rs
@@ -225,7 +225,7 @@ impl Root {
                 .try_bootstrap_root(local_addr, self.shared.node_ident.cluster_id.clone())
                 .await
             {
-                metrics::BOOTSTRAP_FAIL_COUNT.inc();
+                metrics::BOOTSTRAP_FAIL_TOTAL.inc();
                 error!(err = ?err, "boostrap error");
                 panic!("boostrap cluster failure")
             }
@@ -238,7 +238,7 @@ impl Root {
                 schema: Arc::new(schema.to_owned()),
             });
         }
-        self::metrics::LEADER_STATE.set(1);
+        self::metrics::LEADER_STATE_INFO.set(1);
 
         self.heartbeat_queue.enable(true).await;
 
@@ -276,7 +276,7 @@ impl Root {
             *core = None;
         }
 
-        self::metrics::LEADER_STATE.set(0);
+        self::metrics::LEADER_STATE_INFO.set(0);
 
         Ok(())
     }

--- a/src/server/src/root/mod.rs
+++ b/src/server/src/root/mod.rs
@@ -779,7 +779,7 @@ impl Root {
                     .get_replica_state(u.group_id, update_replica_state.replica_id)
                     .await?
                 {
-                    Some(pre_rs) if pre_rs.term >= update_replica_state.term => None,
+                    Some(pre_rs) if pre_rs.term > update_replica_state.term => None,
                     _ => u.replica_state,
                 }
             } else {

--- a/src/server/src/root/schedule.rs
+++ b/src/server/src/root/schedule.rs
@@ -93,7 +93,7 @@ impl ReconcileScheduler {
     }
 
     pub async fn check(&self, max_try_per_tick: u64) -> Result<bool> {
-        let _timer = super::metrics::RECONCILE_CHECK_DURATION.start_timer();
+        let _timer = super::metrics::RECONCILE_CHECK_DURATION_SECONDS.start_timer();
         let group_action = self.ctx.alloc.compute_group_action().await?;
         if let GroupAction::Add(cnt) = group_action {
             for _ in 0..cnt {
@@ -286,13 +286,13 @@ impl ScheduleContext {
         bool, /* immediately step next tick */
     )> {
         metrics::RECONCILE_HANDLE_TASK_TOTAL.create_group.inc();
-        let _timer = metrics::RECONCILE_HANDL_TASK_DURATION
+        let _timer = metrics::RECONCILE_HANDL_TASK_DURATION_SECONDS
             .create_group
             .start_timer();
         loop {
             match CreateGroupTaskStep::from_i32(task.step).unwrap() {
                 CreateGroupTaskStep::GroupInit => {
-                    let _timer = metrics::RECONCILE_CREATE_GROUP_STEP_DURATION
+                    let _timer = metrics::RECONCILE_CREATE_GROUP_STEP_DURATION_SECONDS
                         .init
                         .start_timer();
                     let schema = self.shared.schema()?;
@@ -324,7 +324,7 @@ impl ScheduleContext {
                     }
                 }
                 CreateGroupTaskStep::GroupCreating => {
-                    let _timer = metrics::RECONCILE_CREATE_GROUP_STEP_DURATION
+                    let _timer = metrics::RECONCILE_CREATE_GROUP_STEP_DURATION_SECONDS
                         .create
                         .start_timer();
                     let mut wait_create = task.wait_create.to_owned();
@@ -371,7 +371,7 @@ impl ScheduleContext {
                     }
                 }
                 CreateGroupTaskStep::GroupRollbacking => {
-                    let _timer = metrics::RECONCILE_CREATE_GROUP_STEP_DURATION
+                    let _timer = metrics::RECONCILE_CREATE_GROUP_STEP_DURATION_SECONDS
                         .rollback
                         .start_timer();
                     let mut wait_clean = task.wait_cleanup.to_owned();
@@ -396,7 +396,7 @@ impl ScheduleContext {
                 }
                 CreateGroupTaskStep::GroupAbort => return Ok((true, false)),
                 CreateGroupTaskStep::GroupFinish => {
-                    let _timer = metrics::RECONCILE_CREATE_GROUP_STEP_DURATION
+                    let _timer = metrics::RECONCILE_CREATE_GROUP_STEP_DURATION_SECONDS
                         .finish
                         .start_timer();
                     self.heartbeat_queue
@@ -425,13 +425,13 @@ impl ScheduleContext {
         metrics::RECONCILE_HANDLE_TASK_TOTAL
             .reallocate_replica
             .inc();
-        let _timer = metrics::RECONCILE_HANDL_TASK_DURATION
+        let _timer = metrics::RECONCILE_HANDL_TASK_DURATION_SECONDS
             .reallocate_replica
             .start_timer();
         loop {
             match ReallocateReplicaTaskStep::from_i32(task.step).unwrap() {
                 ReallocateReplicaTaskStep::CreatingDestReplica => {
-                    let _timer = metrics::RECONCILE_REALLOCATE_REPLICA_STEP_DURATION
+                    let _timer = metrics::RECONCILE_REALLOCATE_REPLICA_STEP_DURATION_SECONDS
                         .create_dest_replica
                         .start_timer();
                     let schema = self.shared.schema()?;
@@ -451,7 +451,7 @@ impl ScheduleContext {
                     };
                 }
                 ReallocateReplicaTaskStep::AddDestLearner => {
-                    let _timer = metrics::RECONCILE_REALLOCATE_REPLICA_STEP_DURATION
+                    let _timer = metrics::RECONCILE_REALLOCATE_REPLICA_STEP_DURATION_SECONDS
                         .add_dest_learner
                         .start_timer();
                     let group = task.group;
@@ -470,7 +470,7 @@ impl ScheduleContext {
                     }
                 }
                 ReallocateReplicaTaskStep::ReplaceDestVoter => {
-                    let _timer = metrics::RECONCILE_REALLOCATE_REPLICA_STEP_DURATION
+                    let _timer = metrics::RECONCILE_REALLOCATE_REPLICA_STEP_DURATION_SECONDS
                         .replica_dest_voter
                         .start_timer();
                     let group = task.group;
@@ -489,7 +489,7 @@ impl ScheduleContext {
                     }
                 }
                 ReallocateReplicaTaskStep::ShedSourceLeader => {
-                    let _timer = metrics::RECONCILE_REALLOCATE_REPLICA_STEP_DURATION
+                    let _timer = metrics::RECONCILE_REALLOCATE_REPLICA_STEP_DURATION_SECONDS
                         .shed_src_leader
                         .start_timer();
                     let group = task.group;
@@ -507,7 +507,7 @@ impl ScheduleContext {
                     }
                 }
                 ReallocateReplicaTaskStep::RemoveSourceMembership => {
-                    let _timer = metrics::RECONCILE_REALLOCATE_REPLICA_STEP_DURATION
+                    let _timer = metrics::RECONCILE_REALLOCATE_REPLICA_STEP_DURATION_SECONDS
                         .remove_src_membership
                         .start_timer();
                     let group = task.group;
@@ -525,7 +525,7 @@ impl ScheduleContext {
                     }
                 }
                 ReallocateReplicaTaskStep::RemoveSourceReplica => {
-                    let _timer = metrics::RECONCILE_REALLOCATE_REPLICA_STEP_DURATION
+                    let _timer = metrics::RECONCILE_REALLOCATE_REPLICA_STEP_DURATION_SECONDS
                         .remove_src_replica
                         .start_timer();
                     let r = self.try_remove_replica(task.group, task.src_replica).await;
@@ -543,7 +543,7 @@ impl ScheduleContext {
 
                 ReallocateReplicaTaskStep::ReallocateAbort => return Ok((true, false)),
                 ReallocateReplicaTaskStep::ReallocateFinish => {
-                    let _timer = metrics::RECONCILE_REALLOCATE_REPLICA_STEP_DURATION
+                    let _timer = metrics::RECONCILE_REALLOCATE_REPLICA_STEP_DURATION_SECONDS
                         .finish
                         .start_timer();
                     self.heartbeat_queue
@@ -573,7 +573,7 @@ impl ScheduleContext {
         bool, /* immediately step next tick */
     )> {
         metrics::RECONCILE_HANDLE_TASK_TOTAL.migrate_shard.inc();
-        let _timer = metrics::RECONCILE_HANDL_TASK_DURATION
+        let _timer = metrics::RECONCILE_HANDL_TASK_DURATION_SECONDS
             .migrate_shard
             .start_timer();
         let r = self
@@ -594,7 +594,7 @@ impl ScheduleContext {
         bool, /* immediately step next tick */
     )> {
         metrics::RECONCILE_HANDLE_TASK_TOTAL.transfer_leader.inc();
-        let _timer = metrics::RECONCILE_HANDL_TASK_DURATION
+        let _timer = metrics::RECONCILE_HANDL_TASK_DURATION_SECONDS
             .transfer_leader
             .start_timer();
         let r = self
@@ -630,7 +630,7 @@ impl ScheduleContext {
         metrics::RECONCILE_HANDLE_TASK_TOTAL
             .create_collection_shards
             .inc();
-        let _timer = metrics::RECONCILE_HANDL_TASK_DURATION
+        let _timer = metrics::RECONCILE_HANDL_TASK_DURATION_SECONDS
             .create_collection_shards
             .start_timer();
         loop {
@@ -693,7 +693,7 @@ impl ScheduleContext {
         metrics::RECONCILE_HANDLE_TASK_TOTAL
             .shed_group_leaders
             .inc();
-        let _timer = metrics::RECONCILE_HANDL_TASK_DURATION
+        let _timer = metrics::RECONCILE_HANDL_TASK_DURATION_SECONDS
             .shed_group_leaders
             .start_timer();
         let node = shed.node_id;
@@ -772,7 +772,7 @@ impl ScheduleContext {
         bool, /* immediately step next tick */
     )> {
         metrics::RECONCILE_HANDLE_TASK_TOTAL.shed_root_leader.inc();
-        let _timer = metrics::RECONCILE_HANDL_TASK_DURATION
+        let _timer = metrics::RECONCILE_HANDL_TASK_DURATION_SECONDS
             .shed_root_leader
             .start_timer();
         let node = task.node_id;

--- a/src/server/src/root/schema.rs
+++ b/src/server/src/root/schema.rs
@@ -573,6 +573,8 @@ impl ReplicaNodes {
 // bootstrap schema.
 impl Schema {
     pub async fn try_bootstrap_root(&mut self, addr: &str, cluster_id: Vec<u8>) -> Result<()> {
+        let _timer = super::metrics::BOOTSTRAP_DURATION_SECONDS.start_timer();
+
         if let Some(exist_cluster_id) = self.cluster_id().await? {
             if exist_cluster_id != cluster_id {
                 return Err(Error::ClusterNotMatch);


### PR DESCRIPTION
ref #834

This PR try to add metric related with root process, like: bootstrap, reconcile, heartbeat and watch

It should be a follow-up PR to push current cluster info summary(like: node, group, replica, shard.. as metric) 