### PR TITLE
root: refine info not_found handle in reconcile scheduler

### DIFF
--- a/src/server/src/error.rs
+++ b/src/server/src/error.rs
@@ -87,6 +87,9 @@ pub enum Error {
         /* term */ u64,
         Option<ReplicaDesc>,
     ),
+
+    #[error("abort schedule task, {0}")]
+    AbortScheduleTask(&'static str),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -134,6 +137,7 @@ impl From<Error> for tonic::Status {
             Error::GroupNotReady(_) => panic!("GroupNotReady only used inside node"),
 
             err @ (Error::Canceled
+            | Error::AbortScheduleTask(_)
             | Error::ClusterNotMatch
             | Error::InvalidData(_)
             | Error::Transport(_)
@@ -186,6 +190,7 @@ impl From<Error> for engula_api::server::v1::Error {
             Error::Forward(_) => panic!("Forward only used inside node"),
             Error::ServiceIsBusy(_) => panic!("ServiceIsBusy only used inside node"),
             Error::GroupNotReady(_) => panic!("GroupNotReady only used inside node"),
+            Error::AbortScheduleTask(_) => panic!("AbortScheduleTask only used inside node"),
 
             err @ (Error::Transport(_)
             | Error::ResourceExhausted(_)


### PR DESCRIPTION
fixes #945

Previously, the root reconcile scheduler headlessly threw fake group_not_found to let outer retry & wait for the new update.

But this temporary logic will lead to a mistake like #945, this PR try to refine them.

Currently, reconcile workflow is 1. allocator finds & enqueue task, 2. scheduler consumes task queue and executes the actual task

There is a time interval between "create task" and "execute task", so when we found something in the task mismatched with real cluster info(e.g. task has a group, but the real cluster doesn't) normally it indicate task's info is outdated, so it chooses to abort the task(allocator should recreate task if it's a real need).