### PR TITLE
root: setup group per cpu_core

### DIFF
--- a/conf/default.toml
+++ b/conf/default.toml
@@ -2,6 +2,7 @@ root_dir = "/tmp/engula"
 addr = "127.0.0.1:21805"
 init = false
 join_list = []
+cpu_nums = 0
 
 [node]
 shard_chunk_size = 67108864

--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -58,6 +58,7 @@ struct StartCommand {
     addr: Option<String>,
     #[clap(long)]
     db: Option<String>,
+    cpu_nums: Option<u32>,
 
     #[clap(long, help = "dump config as toml file and exit")]
     dump_config: Option<String>,
@@ -110,6 +111,7 @@ fn load_config(
     let mut builder = Config::builder()
         .set_default("addr", "127.0.0.1:21805")?
         .set_default("init", false)?
+        .set_default("cpu_nums", 0)?
         .set_default("join_list", Vec::<String>::default())?;
 
     if let Some(conf) = cmd.conf.as_ref() {
@@ -121,6 +123,7 @@ fn load_config(
         .set_override_option("addr", cmd.addr.clone())?
         .set_override_option("root_dir", cmd.db.clone())?
         .set_override_option("join_list", cmd.join.clone())?
+        .set_override_option("cpu_nums", cmd.cpu_nums)?
         .set_override_option("init", if cmd.init { Some(true) } else { None })?
         .build()?;
 

--- a/src/server/src/bootstrap.rs
+++ b/src/server/src/bootstrap.rs
@@ -138,7 +138,14 @@ async fn bootstrap_or_join_cluster(
     Ok(if config.init {
         bootstrap_cluster(node, &config.addr).await?
     } else {
-        try_join_cluster(node, &config.addr, config.join_list.clone(), root_client).await?
+        try_join_cluster(
+            node,
+            &config.addr,
+            config.join_list.clone(),
+            config.cpu_nums,
+            root_client,
+        )
+        .await?
     })
 }
 
@@ -146,6 +153,7 @@ async fn try_join_cluster(
     node: &Node,
     local_addr: &str,
     join_list: Vec<String>,
+    cpu_nums: u32,
     root_client: &RootClient,
 ) -> Result<NodeIdent> {
     info!("try join a bootstrapted cluster");
@@ -161,8 +169,13 @@ async fn try_join_cluster(
         ));
     }
 
+    let cpu_nums = if cpu_nums == 0 {
+        num_cpus::get() as f64
+    } else {
+        cpu_nums as f64
+    };
     let capacity = NodeCapacity {
-        cpu_nums: num_cpus::get() as f64,
+        cpu_nums,
         ..Default::default()
     };
 

--- a/src/server/src/lib.rs
+++ b/src/server/src/lib.rs
@@ -53,6 +53,8 @@ pub struct Config {
 
     pub addr: String,
 
+    pub cpu_nums: u32,
+
     pub init: bool,
 
     pub join_list: Vec<String>,

--- a/src/server/src/root/allocator/mod.rs
+++ b/src/server/src/root/allocator/mod.rs
@@ -277,7 +277,7 @@ impl<T: AllocSource> Allocator<T> {
             .iter()
             .map(|n| n.capacity.as_ref().unwrap().cpu_nums)
             .fold(0_f64, |acc, x| acc + x);
-        (total_cpus / self.config.replicas_per_group as f64).ceil() as usize
+        total_cpus as usize
     }
 
     fn current_groups(&self) -> usize {

--- a/src/server/src/root/allocator/sim_test.rs
+++ b/src/server/src/root/allocator/sim_test.rs
@@ -50,7 +50,7 @@ fn sim_boostrap_join_node_balance() {
             id: 1,
             addr: "".into(),
             capacity: Some(NodeCapacity {
-                cpu_nums: 4.0,
+                cpu_nums: 2.0,
                 replica_count: 1,
                 leader_count: 1,
             }),
@@ -76,7 +76,7 @@ fn sim_boostrap_join_node_balance() {
                 id: 2,
                 addr: "".into(),
                 capacity: Some(NodeCapacity {
-                    cpu_nums: 4.0,
+                    cpu_nums: 2.0,
                     replica_count: 0,
                     leader_count: 0,
                 }),
@@ -86,7 +86,7 @@ fn sim_boostrap_join_node_balance() {
                 id: 3,
                 addr: "".into(),
                 capacity: Some(NodeCapacity {
-                    cpu_nums: 4.0,
+                    cpu_nums: 2.0,
                     replica_count: 0,
                     leader_count: 0,
                 }),
@@ -230,7 +230,7 @@ fn sim_boostrap_join_node_balance() {
             id: 4,
             addr: "".into(),
             capacity: Some(NodeCapacity {
-                cpu_nums: 4.0,
+                cpu_nums: 2.0,
                 replica_count: 0,
                 leader_count: 0,
             }),
@@ -321,21 +321,25 @@ fn sim_boostrap_join_node_balance() {
                 }
             }
         }
-        let racts = a.compute_replica_action().await.unwrap();
-        assert!(!racts.is_empty());
-        for act in &racts {
-            match act {
-                ReplicaAction::Migrate(ReallocateReplica {
-                    group,
-                    source_node: _,
-                    source_replica,
-                    target_node,
-                }) => {
-                    println!(
-                        "move group {} replica {} to {}",
-                        group, source_replica, target_node.id
-                    );
-                    p.move_replica(*source_replica, target_node.id)
+        loop {
+            let racts = a.compute_replica_action().await.unwrap();
+            if racts.is_empty() {
+                break;
+            }
+            for act in &racts {
+                match act {
+                    ReplicaAction::Migrate(ReallocateReplica {
+                        group,
+                        source_node: _,
+                        source_replica,
+                        target_node,
+                    }) => {
+                        println!(
+                            "move group {} replica {} to {}",
+                            group, source_replica, target_node.id
+                        );
+                        p.move_replica(*source_replica, target_node.id)
+                    }
                 }
             }
         }

--- a/src/server/src/root/schema.rs
+++ b/src/server/src/root/schema.rs
@@ -665,7 +665,12 @@ impl ReplicaNodes {
 
 // bootstrap schema.
 impl Schema {
-    pub async fn try_bootstrap_root(&mut self, addr: &str, cluster_id: Vec<u8>) -> Result<()> {
+    pub async fn try_bootstrap_root(
+        &mut self,
+        addr: &str,
+        cfg_cpu_nums: u32,
+        cluster_id: Vec<u8>,
+    ) -> Result<()> {
         let _timer = super::metrics::BOOTSTRAP_DURATION_SECONDS.start_timer();
 
         if let Some(exist_cluster_id) = self.cluster_id().await? {
@@ -695,11 +700,16 @@ impl Schema {
             name: SYSTEM_DATABASE_NAME.to_owned(),
         });
 
+        let cpu_nums = if cfg_cpu_nums == 0 {
+            num_cpus::get() as f64
+        } else {
+            cfg_cpu_nums as f64
+        };
         batch.put_node(NodeDesc {
             id: FIRST_NODE_ID,
             addr: addr.into(),
             capacity: Some(NodeCapacity {
-                cpu_nums: num_cpus::get() as f64,
+                cpu_nums,
                 replica_count: 1,
                 leader_count: 0,
             }),

--- a/src/server/tests/helper/context.rs
+++ b/src/server/tests/helper/context.rs
@@ -99,7 +99,7 @@ impl TestContext {
 
     #[allow(dead_code)]
     pub fn spawn_server(&mut self, idx: usize, addr: &str, init: bool, join_list: Vec<String>) {
-        self.spawn_server_with_cfg(idx, addr, init, join_list, self.root_cfg.clone());
+        self.spawn_server_with_cfg(idx, addr, 2, init, join_list, self.root_cfg.clone());
     }
 
     #[allow(dead_code)]
@@ -107,6 +107,7 @@ impl TestContext {
         &mut self,
         idx: usize,
         addr: &str,
+        cpu_nums: u32,
         init: bool,
         join_list: Vec<String>,
         root: RootConfig,
@@ -117,6 +118,7 @@ impl TestContext {
         let cfg = Config {
             root_dir,
             addr,
+            cpu_nums,
             init,
             join_list,
             node: NodeConfig {

--- a/src/server/tests/node_schedule_test.rs
+++ b/src/server/tests/node_schedule_test.rs
@@ -164,6 +164,8 @@ fn remove_offline_learners() {
 fn remove_exceeds_offline_voters() {
     block_on_current(async {
         let mut ctx = TestContext::new("node-schedule-test--remove-exceeds-offline-voters");
+        ctx.mut_replica_testing_knobs()
+            .disable_orphan_replica_detecting_intervals = true;
         ctx.disable_all_balance();
         let nodes = ctx.bootstrap_servers(3).await;
         let c = ClusterClient::new(nodes.clone()).await;


### PR DESCRIPTION
Before this PR, root setup one group per "cpu_core / group-replica-cnt", this makes some cores cannot be used

(e.g. 2c x 3 clusters can only set up 2 groups and one node can be observed as no requests)

This PR change strategy to “one group per cpu_core".

By the way, it also adds a new config item "cpu_nums" to help test multiple processes on a single node in test env.

> In production env, multiple processes on a single node should bind cpu_core(taskset or numactl), engula can auto-detect the bound cpu_core, so normally, it also no need to configure "cpu_nums" in production env