### PR TITLE
bin: upgrade config-rs to v0.13.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea917b74b6edfb5024e3b55d3c8f710b5f4ed92646429601a42e96f0812b31b"
+checksum = "11f1667b8320afa80d69d8bbe40830df2c8a06003d86f73d8e003b2c48df416d"
 dependencies = [
  "async-trait",
  "json5",

--- a/src/bin/Cargo.toml
+++ b/src/bin/Cargo.toml
@@ -14,7 +14,7 @@ default-run = "engula"
 engula-server = { path = "../server", version = "0.4.0" }
 
 clap = { version = "3.1.18", features = ["derive"] }
-config = { version = "0.13.1", features = ["toml"] }
+config = { version = "0.13.2", features = ["toml"] }
 num_cpus = "1.13.1"
 toml = { version = "0.5" }
 tracing = "0.1"

--- a/src/bin/bench/Cargo.toml
+++ b/src/bin/bench/Cargo.toml
@@ -13,7 +13,7 @@ engula-server = { path = "../../server", version = "0.4.0" }
 
 atty = "0.2.14"
 clap = { version = "3.1.18", features = ["derive"] }
-config = { version = "0.13.1", features = ["toml"] }
+config = { version = "0.13.2", features = ["toml"] }
 lazy_static = "1.4.0"
 num_cpus = "1.13.1"
 paste = "1.0"


### PR DESCRIPTION
It fixs `expected an signed 64 bit or less integer for key` reported by config-rs.