### PR TITLE
client: avoid refreshing group state

### DIFF
--- a/src/client/src/app_client.rs
+++ b/src/client/src/app_client.rs
@@ -332,7 +332,7 @@ impl Collection {
     async fn delete_inner(&self, key: &[u8], timeout: Option<Duration>) -> crate::Result<()> {
         let router = self.client.inner.router.clone();
         let (group, shard) = router.find_shard(self.co_desc.clone(), key)?;
-        let mut client = GroupClient::from_group_state(
+        let mut client = GroupClient::new(
             group,
             self.client.inner.router.clone(),
             self.client.inner.conn_manager.clone(),
@@ -358,7 +358,7 @@ impl Collection {
     ) -> crate::Result<()> {
         let router = self.client.inner.router.clone();
         let (group, shard) = router.find_shard(self.co_desc.clone(), key)?;
-        let mut client = GroupClient::from_group_state(
+        let mut client = GroupClient::new(
             group,
             self.client.inner.router.clone(),
             self.client.inner.conn_manager.clone(),
@@ -384,7 +384,7 @@ impl Collection {
     ) -> crate::Result<Option<Vec<u8>>> {
         let router = self.client.inner.router.clone();
         let (group, shard) = router.find_shard(self.co_desc.clone(), key)?;
-        let mut client = GroupClient::from_group_state(
+        let mut client = GroupClient::new(
             group,
             self.client.inner.router.clone(),
             self.client.inner.conn_manager.clone(),

--- a/src/client/src/migrate_client.rs
+++ b/src/client/src/migrate_client.rs
@@ -96,7 +96,7 @@ impl MigrateClient {
 
     #[inline]
     fn group_client(&self) -> GroupClient {
-        GroupClient::new(
+        GroupClient::lazy(
             self.group_id,
             self.router.clone(),
             self.conn_manager.clone(),

--- a/src/client/src/shard_client.rs
+++ b/src/client/src/shard_client.rs
@@ -71,7 +71,7 @@ impl ShardClient {
             shard_id: self.shard_id,
             prefix: prefix.to_owned(),
         });
-        let mut client = GroupClient::new(
+        let mut client = GroupClient::lazy(
             self.group_id,
             self.router.clone(),
             self.conn_manager.clone(),
@@ -91,7 +91,7 @@ impl ShardClient {
                 key: key.to_owned(),
             }),
         });
-        let mut client = GroupClient::new(
+        let mut client = GroupClient::lazy(
             self.group_id,
             self.router.clone(),
             self.conn_manager.clone(),

--- a/src/server/src/root/bg_job.rs
+++ b/src/server/src/root/bg_job.rs
@@ -159,6 +159,7 @@ impl Jobs {
                 return Err(crate::Error::ResourceExhausted("no engouth groups".into()));
             }
             let group = groups.first().unwrap();
+            info!("try create shard at group {}", group.id);
             if let Err(err) = self.try_create_shard(group.id, &shard).await {
                 error!(group=group.id, shard=shard.id, err=?err, "create collection shard error and try to rollback");
                 create_collection.remark = format!("{err:?}");
@@ -564,7 +565,7 @@ impl Jobs {
 
 impl Jobs {
     async fn try_create_shard(&self, group_id: u64, desc: &ShardDesc) -> Result<()> {
-        let mut group_client = GroupClient::new(
+        let mut group_client = GroupClient::lazy(
             group_id,
             self.core.root_shared.provider.router.clone(),
             self.core.root_shared.provider.conn_manager.clone(),

--- a/src/server/src/root/schedule.rs
+++ b/src/server/src/root/schedule.rs
@@ -673,7 +673,7 @@ impl ScheduleContext {
         incoming_replica: ReplicaDesc,
         outgoing_replica: ReplicaDesc,
     ) -> Result<ScheduleState> {
-        let mut group_client = GroupClient::new(
+        let mut group_client = GroupClient::lazy(
             group,
             self.shared.provider.router.clone(),
             self.shared.provider.conn_manager.clone(),
@@ -685,7 +685,7 @@ impl ScheduleContext {
     }
 
     async fn try_transfer_leader(&self, group: u64, target_replica: u64) -> Result<()> {
-        let mut group_client = GroupClient::new(
+        let mut group_client = GroupClient::lazy(
             group,
             self.shared.provider.router.clone(),
             self.shared.provider.conn_manager.clone(),
@@ -705,7 +705,7 @@ impl ScheduleContext {
             crate::Error::AbortScheduleTask("migrate shard has be moved out"),
         )?;
 
-        let mut group_client = GroupClient::new(
+        let mut group_client = GroupClient::lazy(
             target_group,
             self.shared.provider.router.clone(),
             self.shared.provider.conn_manager.clone(),

--- a/src/server/tests/helper/client.rs
+++ b/src/server/tests/helper/client.rs
@@ -67,7 +67,7 @@ impl ClusterClient {
     }
 
     pub fn group(&self, group_id: u64) -> GroupClient {
-        GroupClient::new(group_id, self.router.clone(), self.conn_manager.clone())
+        GroupClient::lazy(group_id, self.router.clone(), self.conn_manager.clone())
     }
 
     pub async fn app_client(&self) -> EngulaClient {

--- a/src/server/tests/helper/socket.rs
+++ b/src/server/tests/helper/socket.rs
@@ -18,16 +18,31 @@ use socket2::{Domain, Socket, Type};
 
 /// Find the next available port to listen on.
 pub fn next_avail_port() -> u16 {
-    let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
-    socket.set_reuse_address(true).unwrap();
-    socket.set_reuse_port(true).unwrap();
-    socket
-        .bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap().into())
-        .unwrap();
-    socket
-        .local_addr()
-        .unwrap()
-        .as_socket_ipv4()
-        .unwrap()
-        .port()
+    next_n_avail_port(1)[0]
+}
+
+pub fn next_n_avail_port(n: usize) -> Vec<u16> {
+    let sockets = (0..n)
+        .into_iter()
+        .map(|_| {
+            let socket = Socket::new(Domain::IPV4, Type::STREAM, None).unwrap();
+            socket.set_reuse_address(true).unwrap();
+            socket.set_reuse_port(true).unwrap();
+            socket
+                .bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap().into())
+                .unwrap();
+            socket
+        })
+        .collect::<Vec<_>>();
+    sockets
+        .into_iter()
+        .map(|socket| {
+            socket
+                .local_addr()
+                .unwrap()
+                .as_socket_ipv4()
+                .unwrap()
+                .port()
+        })
+        .collect()
 }

--- a/src/server/tests/helper/socket.rs
+++ b/src/server/tests/helper/socket.rs
@@ -22,6 +22,7 @@ pub fn next_avail_port() -> u16 {
 }
 
 pub fn next_n_avail_port(n: usize) -> Vec<u16> {
+    #[allow(clippy::needless_collect)]
     let sockets = (0..n)
         .into_iter()
         .map(|_| {


### PR DESCRIPTION
Refreshing the group state may get the updated group desc, and some requests, such as `ShardGetRequest`, require the epoch to be the same as when the `GroupClient` was created, otherwise a `ShardNotFound` error will returned.