### PR TITLE
*: upgrade rust toolchain to 1.65

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2022-06-08"
+channel = "nightly-2022-09-08"
 components = ["rustfmt", "clippy"]

--- a/src/client/src/metrics.rs
+++ b/src/client/src/metrics.rs
@@ -57,7 +57,7 @@ lazy_static! {
     )
     .unwrap();
     pub static ref GROUP_CLIENT_GROUP_REQUEST_TOTAL: GroupRequestTotal =
-        GroupRequestTotal::from(&*GROUP_CLIENT_GROUP_REQUEST_TOTAL_VEC);
+        GroupRequestTotal::from(&GROUP_CLIENT_GROUP_REQUEST_TOTAL_VEC);
     pub static ref GROUP_CLIENT_GROUP_REQUEST_DURATION_SECONDS_VEC: HistogramVec =
         register_histogram_vec!(
             "group_client_group_request_duration_seconds",
@@ -67,7 +67,7 @@ lazy_static! {
         )
         .unwrap();
     pub static ref GROUP_CLIENT_GROUP_REQUEST_DURATION_SECONDS: GroupRequestDuration =
-        GroupRequestDuration::from(&*GROUP_CLIENT_GROUP_REQUEST_DURATION_SECONDS_VEC);
+        GroupRequestDuration::from(&GROUP_CLIENT_GROUP_REQUEST_DURATION_SECONDS_VEC);
     pub static ref GROUP_CLIENT_RETRY_TOTAL: IntCounter = register_int_counter!(
         "group_client_retry_total",
         "The total retries of group client",
@@ -155,7 +155,7 @@ lazy_static! {
     )
     .unwrap();
     pub static ref CLIENT_DATABASE_REQUEST_TOTAL: DatabaseRequestTotal =
-        DatabaseRequestTotal::from(&*CLIENT_DATABASE_REQUEST_TOTAL_VEC);
+        DatabaseRequestTotal::from(&CLIENT_DATABASE_REQUEST_TOTAL_VEC);
     pub static ref CLIENT_DATABASE_REQUEST_DURATION_SECONDS_VEC: HistogramVec =
         register_histogram_vec!(
             "client_database_request_duration_seconds",
@@ -165,7 +165,7 @@ lazy_static! {
         )
         .unwrap();
     pub static ref CLIENT_DATABASE_REQUEST_DURATION_SECONDS: DatabaseRequestDuration =
-        DatabaseRequestDuration::from(&*CLIENT_DATABASE_REQUEST_DURATION_SECONDS_VEC);
+        DatabaseRequestDuration::from(&CLIENT_DATABASE_REQUEST_DURATION_SECONDS_VEC);
     pub static ref CLIENT_DATABASE_BYTES_TOTAL_VEC: IntCounterVec = register_int_counter_vec!(
         "client_database_bytes_total",
         "The total bytes of client database receive/send",
@@ -173,7 +173,7 @@ lazy_static! {
     )
     .unwrap();
     pub static ref CLIENT_DATABASE_BYTES_TOTAL: DatabaseBytesTotal =
-        DatabaseBytesTotal::from(&*CLIENT_DATABASE_BYTES_TOTAL_VEC);
+        DatabaseBytesTotal::from(&CLIENT_DATABASE_BYTES_TOTAL_VEC);
 }
 
 #[macro_export]

--- a/src/server/src/lib.rs
+++ b/src/server/src/lib.rs
@@ -15,8 +15,7 @@
 #![feature(cursor_remaining)]
 #![feature(drain_filter)]
 #![feature(linked_list_cursors)]
-#![feature(result_into_ok_or_err)]
-#![feature(path_try_exists)]
+#![feature(fs_try_exists)]
 
 mod bootstrap;
 mod discovery;

--- a/src/server/src/raftgroup/node.rs
+++ b/src/server/src/raftgroup/node.rs
@@ -792,7 +792,7 @@ mod tests {
             fn apply_snapshot(&mut self, data: &std::path::Path) -> crate::Result<()> {
                 use prost::Message;
 
-                let content = std::fs::read(&data).unwrap();
+                let content = std::fs::read(data).unwrap();
                 let meta = SnapshotMeta::decode(&*content).unwrap();
                 self.flushed_index = meta.apply_state.unwrap().index;
                 Ok(())

--- a/src/server/src/raftgroup/snap/download.rs
+++ b/src/server/src/raftgroup/snap/download.rs
@@ -85,7 +85,7 @@ impl SnapshotBuilder {
         let str = OsString::from_vec(name.clone());
         let path = self.base_dir.join(str);
         if let Some(parent) = path.parent() {
-            if !std::fs::try_exists(&parent)? {
+            if !std::fs::try_exists(parent)? {
                 std::fs::create_dir_all(parent)?;
             }
         }

--- a/src/server/src/root/schema.rs
+++ b/src/server/src/root/schema.rs
@@ -437,14 +437,14 @@ impl Schema {
                 Entry::Occupied(mut ent) => {
                     let group = ent.get_mut();
                     if state.role == RaftRole::Leader as i32 {
-                        (*group).leader_id = Some(state.replica_id);
-                    } else if (*group).leader_id == Some(state.replica_id) {
-                        (*group).leader_id = None;
+                        group.leader_id = Some(state.replica_id);
+                    } else if group.leader_id == Some(state.replica_id) {
+                        group.leader_id = None;
                     }
-                    (*group)
+                    group
                         .replicas
                         .retain(|desc| desc.replica_id != state.replica_id);
-                    (*group).replicas.push(state);
+                    group.replicas.push(state);
                 }
                 Entry::Vacant(ent) => {
                     let leader_id = if state.role == RaftRole::Leader as i32 {

--- a/src/server/src/service/metrics.rs
+++ b/src/server/src/service/metrics.rs
@@ -56,7 +56,7 @@ lazy_static! {
     )
     .unwrap();
     pub static ref NODE_SERVICE_GROUP_REQUEST_TOTAL: GroupRequestTotal =
-        GroupRequestTotal::from(&*NODE_SERVICE_GROUP_REQUEST_TOTAL_VEC);
+        GroupRequestTotal::from(&NODE_SERVICE_GROUP_REQUEST_TOTAL_VEC);
     pub static ref NODE_SERVICE_GROUP_REQUEST_DURATION_SECONDS_VEC: HistogramVec =
         register_histogram_vec!(
             "node_service_group_request_duration_seconds",
@@ -66,7 +66,7 @@ lazy_static! {
         )
         .unwrap();
     pub static ref NODE_SERVICE_GROUP_REQUEST_DURATION_SECONDS: GroupRequestDuration =
-        GroupRequestDuration::from(&*NODE_SERVICE_GROUP_REQUEST_DURATION_SECONDS_VEC);
+        GroupRequestDuration::from(&NODE_SERVICE_GROUP_REQUEST_DURATION_SECONDS_VEC);
 }
 
 pub fn take_group_request_metrics(request: &GroupRequest) -> Option<&'static Histogram> {
@@ -140,7 +140,7 @@ lazy_static! {
 pub fn take_batch_request_metrics(request: &BatchRequest) -> &'static Histogram {
     NODE_SERVICE_BATCH_REQUEST_SIZE.observe(request.requests.len() as f64);
     NODE_SERVICE_BATCH_REQUEST_TOTAL.inc();
-    &*NODE_SERVICE_BATCH_REQUEST_DURATION_SECONDS
+    &NODE_SERVICE_BATCH_REQUEST_DURATION_SECONDS
 }
 
 macro_rules! simple_node_method {
@@ -254,7 +254,7 @@ lazy_static! {
         )
         .unwrap();
     pub static ref PROXY_SERVICE_DATABASE_REQUEST_TOTAL: DatabaseRequestTotal =
-        DatabaseRequestTotal::from(&*PROXY_SERVICE_DATABASE_REQUEST_TOTAL_VEC);
+        DatabaseRequestTotal::from(&PROXY_SERVICE_DATABASE_REQUEST_TOTAL_VEC);
     pub static ref PROXY_SERVICE_DATABASE_REQUEST_DURATION_SECONDS_VEC: HistogramVec =
         register_histogram_vec!(
             "proxy_service_database_request_duration_seconds",
@@ -264,7 +264,7 @@ lazy_static! {
         )
         .unwrap();
     pub static ref PROXY_SERVICE_DATABASE_REQUEST_DURATION_SECONDS: DatabaseRequestDuration =
-        DatabaseRequestDuration::from(&*PROXY_SERVICE_DATABASE_REQUEST_DURATION_SECONDS_VEC);
+        DatabaseRequestDuration::from(&PROXY_SERVICE_DATABASE_REQUEST_DURATION_SECONDS_VEC);
 }
 
 pub fn take_database_request_metrics(

--- a/src/server/tests/admin_test.rs
+++ b/src/server/tests/admin_test.rs
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#![feature(backtrace)]
-
 mod helper;
 
 use std::time::Duration;

--- a/src/server/tests/bootstrap_test.rs
+++ b/src/server/tests/bootstrap_test.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![feature(backtrace)]
-
 mod helper;
 
 use engula_server::Result;

--- a/src/server/tests/client_test.rs
+++ b/src/server/tests/client_test.rs
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#![feature(backtrace)]
-
 mod helper;
 
 use std::time::Duration;

--- a/src/server/tests/group_test.rs
+++ b/src/server/tests/group_test.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![feature(backtrace)]
-
 mod helper;
 
 use engula_api::server::v1::*;

--- a/src/server/tests/migration_test.rs
+++ b/src/server/tests/migration_test.rs
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#![feature(backtrace)]
-
 mod helper;
 
 use std::time::Duration;

--- a/src/server/tests/node_schedule_test.rs
+++ b/src/server/tests/node_schedule_test.rs
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![feature(backtrace)]
-
 mod helper;
 
 use std::collections::HashSet;

--- a/src/server/tests/rw_test.rs
+++ b/src/server/tests/rw_test.rs
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#![feature(backtrace)]
-
 mod helper;
 
 use engula_api::server::v1::ReplicaRole;

--- a/src/server/tests/snapshot_test.rs
+++ b/src/server/tests/snapshot_test.rs
@@ -11,9 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-#![feature(backtrace)]
-
 mod helper;
 
 use engula_api::{


### PR DESCRIPTION
Notes:
- features:
  * backtrace stabled
  * path_try_exists => file_try_exists
  * into_ok_or_err  => removed
- fix clippy