### PR TITLE
server: fsm support plug & group commit

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 ###### CONFIG ######
-MODE=release
+MODE=debug
 
 # The working dir of the target cluster envs.
 BASE_DIR=$(pwd)/cluster_test

--- a/src/server/src/lib.rs
+++ b/src/server/src/lib.rs
@@ -16,6 +16,7 @@
 #![feature(drain_filter)]
 #![feature(linked_list_cursors)]
 #![feature(fs_try_exists)]
+#![feature(let_else)]
 
 mod bootstrap;
 mod config;

--- a/src/server/src/node/engine/group.rs
+++ b/src/server/src/node/engine/group.rs
@@ -1114,16 +1114,18 @@ mod tests {
             executor.block_on(async move { GroupEngine::create(db.clone(), 1, 1).await.unwrap() });
 
         let wb = WriteBatch::default();
-        let mut states = WriteStates::default();
-        states.descriptor = Some(GroupDesc {
-            id: group_id,
-            shards: vec![ShardDesc {
-                id: shard_id,
-                collection_id: 1,
-                partition: Some(Partition::Range(RangePartition { start, end })),
-            }],
+        let states = WriteStates {
+            descriptor: Some(GroupDesc {
+                id: group_id,
+                shards: vec![ShardDesc {
+                    id: shard_id,
+                    collection_id: 1,
+                    partition: Some(Partition::Range(RangePartition { start, end })),
+                }],
+                ..Default::default()
+            }),
             ..Default::default()
-        });
+        };
 
         group_engine.commit(wb, states, false).unwrap();
 
@@ -1374,29 +1376,32 @@ mod tests {
         // Add new shard
         use shard_desc::*;
         let wb = WriteBatch::default();
-        let mut states = WriteStates::default();
-        states.descriptor = Some(GroupDesc {
-            id: 1,
-            shards: vec![
-                ShardDesc {
-                    id: 1,
-                    collection_id: 1,
-                    partition: Some(Partition::Range(RangePartition {
-                        start: vec![],
-                        end: b"b".to_vec(),
-                    })),
-                },
-                ShardDesc {
-                    id: 2,
-                    collection_id: 1,
-                    partition: Some(Partition::Range(RangePartition {
-                        start: b"b".to_vec(),
-                        end: vec![],
-                    })),
-                },
-            ],
+        let states = WriteStates {
+            descriptor: Some(GroupDesc {
+                id: 1,
+                shards: vec![
+                    ShardDesc {
+                        id: 1,
+                        collection_id: 1,
+                        partition: Some(Partition::Range(RangePartition {
+                            start: vec![],
+                            end: b"b".to_vec(),
+                        })),
+                    },
+                    ShardDesc {
+                        id: 2,
+                        collection_id: 1,
+                        partition: Some(Partition::Range(RangePartition {
+                            start: b"b".to_vec(),
+                            end: vec![],
+                        })),
+                    },
+                ],
+                ..Default::default()
+            }),
             ..Default::default()
-        });
+        };
+
         group_engine.commit(wb, states, false).unwrap();
 
         // Iterate shard 1
@@ -1432,29 +1437,31 @@ mod tests {
         // Add new shard
         use shard_desc::*;
         let wb = WriteBatch::default();
-        let mut states = WriteStates::default();
-        states.descriptor = Some(GroupDesc {
-            id: 1,
-            shards: vec![
-                ShardDesc {
-                    id: 1,
-                    collection_id: 1,
-                    partition: Some(Partition::Hash(HashPartition {
-                        slot_id: shard_1_slot_id,
-                        slots,
-                    })),
-                },
-                ShardDesc {
-                    id: 2,
-                    collection_id: 1,
-                    partition: Some(Partition::Hash(HashPartition {
-                        slot_id: shard_2_slot_id,
-                        slots,
-                    })),
-                },
-            ],
+        let states = WriteStates {
+            descriptor: Some(GroupDesc {
+                id: 1,
+                shards: vec![
+                    ShardDesc {
+                        id: 1,
+                        collection_id: 1,
+                        partition: Some(Partition::Hash(HashPartition {
+                            slot_id: shard_1_slot_id,
+                            slots,
+                        })),
+                    },
+                    ShardDesc {
+                        id: 2,
+                        collection_id: 1,
+                        partition: Some(Partition::Hash(HashPartition {
+                            slot_id: shard_2_slot_id,
+                            slots,
+                        })),
+                    },
+                ],
+                ..Default::default()
+            }),
             ..Default::default()
-        });
+        };
         group_engine.commit(wb, states, false).unwrap();
 
         let mut wb = WriteBatch::default();

--- a/src/server/src/node/engine/mod.rs
+++ b/src/server/src/node/engine/mod.rs
@@ -16,6 +16,9 @@ mod group;
 mod state;
 
 pub use self::{
-    group::{GroupEngine, RawIterator, Snapshot, SnapshotMode, WriteBatch, LOCAL_COLLECTION_ID},
+    group::{
+        GroupEngine, RawIterator, Snapshot, SnapshotMode, WriteBatch, WriteStates,
+        LOCAL_COLLECTION_ID,
+    },
     state::StateEngine,
 };

--- a/src/server/src/node/replica/fsm/checkpoint.rs
+++ b/src/server/src/node/replica/fsm/checkpoint.rs
@@ -184,19 +184,21 @@ mod tests {
 
         let group_engine = GroupEngine::create(db.clone(), group_id, 1).await.unwrap();
         let wb = WriteBatch::default();
-        let mut states = WriteStates::default();
-        states.descriptor = Some(GroupDesc {
-            id: group_id,
-            shards: vec![ShardDesc {
-                id: shard_id,
-                collection_id: 1,
-                partition: Some(Partition::Range(RangePartition {
-                    start: vec![],
-                    end: vec![],
-                })),
-            }],
+        let states = WriteStates {
+            descriptor: Some(GroupDesc {
+                id: group_id,
+                shards: vec![ShardDesc {
+                    id: shard_id,
+                    collection_id: 1,
+                    partition: Some(Partition::Range(RangePartition {
+                        start: vec![],
+                        end: vec![],
+                    })),
+                }],
+                ..Default::default()
+            }),
             ..Default::default()
-        });
+        };
         group_engine.commit(wb, states, false).unwrap();
 
         group_engine

--- a/src/server/src/node/replica/fsm/checkpoint.rs
+++ b/src/server/src/node/replica/fsm/checkpoint.rs
@@ -211,7 +211,7 @@ mod tests {
                 .put(&mut wb, shard_id, key.as_bytes(), &value, 0)
                 .unwrap();
         }
-        engine.commit(wb, false).unwrap();
+        engine.commit(wb, WriteStates::default(), false).unwrap();
     }
 
     // This test aims to fix bug:

--- a/src/server/src/node/replica/fsm/checkpoint.rs
+++ b/src/server/src/node/replica/fsm/checkpoint.rs
@@ -169,7 +169,10 @@ mod tests {
 
     use super::*;
     use crate::{
-        node::{engine::WriteBatch, GroupEngine},
+        node::{
+            engine::{WriteBatch, WriteStates},
+            GroupEngine,
+        },
         runtime::ExecutorOwner,
     };
 
@@ -180,23 +183,21 @@ mod tests {
         let db = Arc::new(db);
 
         let group_engine = GroupEngine::create(db.clone(), group_id, 1).await.unwrap();
-        let mut wb = WriteBatch::default();
-        group_engine.set_group_desc(
-            &mut wb,
-            &GroupDesc {
-                id: group_id,
-                shards: vec![ShardDesc {
-                    id: shard_id,
-                    collection_id: 1,
-                    partition: Some(Partition::Range(RangePartition {
-                        start: vec![],
-                        end: vec![],
-                    })),
-                }],
-                ..Default::default()
-            },
-        );
-        group_engine.commit(wb, false).unwrap();
+        let wb = WriteBatch::default();
+        let mut states = WriteStates::default();
+        states.descriptor = Some(GroupDesc {
+            id: group_id,
+            shards: vec![ShardDesc {
+                id: shard_id,
+                collection_id: 1,
+                partition: Some(Partition::Range(RangePartition {
+                    start: vec![],
+                    end: vec![],
+                })),
+            }],
+            ..Default::default()
+        });
+        group_engine.commit(wb, states, false).unwrap();
 
         group_engine
     }

--- a/src/server/src/raftgroup/fsm.rs
+++ b/src/server/src/raftgroup/fsm.rs
@@ -30,7 +30,9 @@ pub enum ApplyEntry {
 
 /// An abstraction of finate state machine. It is used by `RaftNode` to apply entries.
 pub trait StateMachine: Send {
+    fn start_plug(&mut self) -> Result<()>;
     fn apply(&mut self, index: u64, term: u64, entry: ApplyEntry) -> Result<()>;
+    fn finish_plug(&mut self) -> Result<()>;
 
     fn apply_snapshot(&mut self, snap_dir: &Path) -> Result<()>;
 

--- a/src/server/src/raftgroup/node.rs
+++ b/src/server/src/raftgroup/node.rs
@@ -506,6 +506,10 @@ mod tests {
         flushed_index: u64,
     }
     impl StateMachine for SimpleStateMachine {
+        fn start_plug(&mut self) -> crate::Result<()> {
+            Ok(())
+        }
+
         #[allow(unused)]
         fn apply(
             &mut self,
@@ -513,6 +517,10 @@ mod tests {
             term: u64,
             entry: crate::raftgroup::ApplyEntry,
         ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        fn finish_plug(&mut self) -> crate::Result<()> {
             Ok(())
         }
 
@@ -777,6 +785,10 @@ mod tests {
         }
 
         impl StateMachine for CheckIndexStateMachine {
+            fn start_plug(&mut self) -> crate::Result<()> {
+                Ok(())
+            }
+
             #[allow(unused)]
             fn apply(
                 &mut self,
@@ -786,6 +798,10 @@ mod tests {
             ) -> crate::Result<()> {
                 assert_eq!(self.flushed_index + 1, index);
                 self.flushed_index = index;
+                Ok(())
+            }
+
+            fn finish_plug(&mut self) -> crate::Result<()> {
                 Ok(())
             }
 

--- a/src/server/src/serverpb.rs
+++ b/src/server/src/serverpb.rs
@@ -83,4 +83,13 @@ pub mod v1 {
             self.get_shard_desc().id
         }
     }
+
+    impl From<&raft::eraftpb::Entry> for EntryId {
+        fn from(e: &raft::eraftpb::Entry) -> Self {
+            EntryId {
+                index: e.index,
+                term: e.term,
+            }
+        }
+    }
 }


### PR DESCRIPTION
rocksdb::Write takes a long time, so use the plug mechanism to save a batch of log entries into a write batch to reduce the overhead of rocksdb::Write.