### PR TITLE
server: reduce execute group request overhead

### DIFF
--- a/src/server/src/root/store.rs
+++ b/src/server/src/root/store.rs
@@ -109,6 +109,6 @@ impl RootStore {
             request: Some(GroupRequestUnion { request: Some(req) }),
         };
 
-        execute(&self.replica, ExecCtx::default(), request).await
+        execute(&self.replica, &ExecCtx::default(), &request).await
     }
 }


### PR DESCRIPTION
1. avoid unnecessary spawn if group has only 1 request
2. reduce upvars size of generator