### PR TITLE
*: upgrade rust-rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,7 @@ dependencies = [
 [[package]]
 name = "librocksdb-sys"
 version = "0.8.0+7.4.4"
-source = "git+https://github.com/w41ter/rust-rocksdb.git?branch=v7.4.4-patched#d156898d660714310b64f21626e1c9a0e74a0864"
+source = "git+https://github.com/w41ter/rust-rocksdb.git?branch=v7.4.4-patched#457c851b9babd61aa8a4423ed74282034c6484e4"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -1953,7 +1953,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.19.0"
-source = "git+https://github.com/w41ter/rust-rocksdb.git?branch=v7.4.4-patched#d156898d660714310b64f21626e1c9a0e74a0864"
+source = "git+https://github.com/w41ter/rust-rocksdb.git?branch=v7.4.4-patched#457c851b9babd61aa8a4423ed74282034c6484e4"
 dependencies = [
  "libc",
  "librocksdb-sys",


### PR DESCRIPTION
rust-rocksdb does not apply -DROCKSDB_RANGESYNC_PRESENT and -DROCKSDB_FALLOCATE_PRESENT, this PR add it.