### PR TITLE
root: reduce desired groups

### DIFF
--- a/src/server/src/root/allocator/sim_test.rs
+++ b/src/server/src/root/allocator/sim_test.rs
@@ -244,7 +244,6 @@ fn sim_boostrap_join_node_balance() {
         let act = a.compute_group_action().await.unwrap();
         match act {
             GroupAction::Add(n) => {
-                assert!(matches!(n, 2));
                 for _ in 0..n {
                     let nodes = a
                         .allocate_group_replica(vec![], REPLICA_PER_GROUP)


### PR DESCRIPTION
According to performance test, too much groups in a core will causes high latency spikes, since both leader and followers need to write and apply entries, the thread might blocks entirely and left the others tasks starvation.