### PR TITLE
server: set cf options from config

### DIFF
--- a/src/server/src/bootstrap.rs
+++ b/src/server/src/bootstrap.rs
@@ -20,7 +20,11 @@ use tracing::{debug, info, warn};
 
 use crate::{
     discovery::RootDiscovery,
-    node::{engine::StateEngine, resolver::AddressResolver, Node},
+    node::{
+        engine::{RawDb, StateEngine},
+        resolver::AddressResolver,
+        Node,
+    },
     root::{Root, Schema},
     runtime::{Executor, Shutdown},
     serverpb::v1::{raft_server::RaftServer, NodeIdent},
@@ -108,70 +112,24 @@ async fn bootstrap_services(
     Ok(())
 }
 
-pub(crate) fn open_engine<P: AsRef<Path>>(cfg: &DbConfig, path: P) -> Result<rocksdb::DB> {
-    use rocksdb::{BlockBasedIndexType, BlockBasedOptions, Cache, Options, DB};
+pub(crate) fn open_engine<P: AsRef<Path>>(cfg: &DbConfig, path: P) -> Result<RawDb> {
+    use rocksdb::DB;
 
     std::fs::create_dir_all(&path)?;
-
-    let mut opts = Options::default();
-    opts.create_if_missing(true);
-    opts.create_missing_column_families(true);
-
-    opts.set_max_background_jobs(cfg.max_background_jobs);
-    opts.set_max_subcompactions(cfg.max_sub_compactions);
-    opts.set_max_manifest_file_size(cfg.max_manifest_file_size);
-    opts.set_bytes_per_sync(cfg.bytes_per_sync);
-    opts.set_compaction_readahead_size(cfg.compaction_readahead_size);
-    opts.set_use_direct_reads(cfg.use_direct_read);
-    opts.set_use_direct_io_for_flush_and_compaction(cfg.use_direct_io_for_flush_and_compaction);
-    opts.set_avoid_unnecessary_blocking_io(cfg.avoid_unnecessary_blocking_io);
-
-    opts.set_write_buffer_size(cfg.write_buffer_size);
-    opts.set_max_write_buffer_number(cfg.max_write_buffer_number);
-    opts.set_min_write_buffer_number_to_merge(cfg.min_write_buffer_number_to_merge);
-
-    opts.set_num_levels(cfg.num_levels);
-    opts.set_compression_per_level(&cfg.compression_per_level);
-
-    opts.set_level_zero_file_num_compaction_trigger(cfg.level0_file_num_compaction_trigger);
-    opts.set_target_file_size_base(cfg.target_file_size_base);
-    opts.set_max_bytes_for_level_base(cfg.max_bytes_for_level_base);
-    opts.set_max_bytes_for_level_multiplier(cfg.max_bytes_for_level_multiplier);
-    opts.set_max_compaction_bytes(cfg.max_compaction_bytes);
-    opts.set_level_compaction_dynamic_level_bytes(true);
-
-    opts.set_level_zero_slowdown_writes_trigger(cfg.level0_slowdown_writes_trigger);
-    opts.set_level_zero_stop_writes_trigger(cfg.level0_slowdown_writes_trigger);
-    opts.set_soft_pending_compaction_bytes_limit(cfg.soft_pending_compaction_bytes_limit);
-    opts.set_hard_pending_compaction_bytes_limit(cfg.hard_pending_compaction_bytes_limit);
-
-    opts.set_auto_tuned_ratelimiter(
-        cfg.rate_limiter_bytes_per_sec,
-        cfg.rate_limiter_refill_period,
-        10,
-        cfg.rate_limiter_auto_tuned,
-    );
-
-    let cache = Cache::new_lru_cache(cfg.block_cache_size)?;
-
-    let mut blk_opts = BlockBasedOptions::default();
-    blk_opts.set_index_type(BlockBasedIndexType::TwoLevelIndexSearch);
-    blk_opts.set_block_size(cfg.block_size);
-    blk_opts.set_block_cache(&cache);
-    blk_opts.set_cache_index_and_filter_blocks(true);
-    blk_opts.set_bloom_filter(10.0, false);
-    opts.set_block_based_table_factory(&blk_opts);
+    let options = cfg.to_options();
 
     // List column families and open database with column families.
-    match DB::list_cf(&Options::default(), &path) {
+    match DB::list_cf(&options, &path) {
         Ok(cfs) => {
             debug!("open local db with {} column families", cfs.len());
-            Ok(DB::open_cf(&opts, path, cfs)?)
+            let db = DB::open_cf(&options, path, cfs)?;
+            Ok(RawDb { db, options })
         }
         Err(e) => {
             if e.as_ref().ends_with("CURRENT: No such file or directory") {
                 info!("create new local db");
-                Ok(DB::open(&opts, &path)?)
+                let db = DB::open(&options, &path)?;
+                Ok(RawDb { db, options })
             } else {
                 Err(e.into())
             }
@@ -363,6 +321,6 @@ pub(crate) async fn build_provider(config: &Config) -> Result<Arc<Provider>> {
 }
 
 #[cfg(test)]
-pub(crate) fn open_engine_with_default_config<P: AsRef<Path>>(path: P) -> Result<rocksdb::DB> {
+pub(crate) fn open_engine_with_default_config<P: AsRef<Path>>(path: P) -> Result<RawDb> {
     open_engine(&DbConfig::default(), path)
 }

--- a/src/server/src/config.rs
+++ b/src/server/src/config.rs
@@ -94,6 +94,66 @@ pub struct DbConfig {
     pub rate_limiter_auto_tuned: bool,
 }
 
+impl DbConfig {
+    pub fn to_options(&self) -> rocksdb::Options {
+        use rocksdb::{BlockBasedIndexType, BlockBasedOptions, Cache, Options};
+
+        let cfg = self;
+
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+
+        opts.set_max_background_jobs(cfg.max_background_jobs);
+        opts.set_max_subcompactions(cfg.max_sub_compactions);
+        opts.set_max_manifest_file_size(cfg.max_manifest_file_size);
+        opts.set_bytes_per_sync(cfg.bytes_per_sync);
+        opts.set_compaction_readahead_size(cfg.compaction_readahead_size);
+        opts.set_use_direct_reads(cfg.use_direct_read);
+        opts.set_use_direct_io_for_flush_and_compaction(cfg.use_direct_io_for_flush_and_compaction);
+        opts.set_avoid_unnecessary_blocking_io(cfg.avoid_unnecessary_blocking_io);
+
+        opts.set_write_buffer_size(cfg.write_buffer_size);
+        opts.set_max_write_buffer_number(cfg.max_write_buffer_number);
+        opts.set_min_write_buffer_number_to_merge(cfg.min_write_buffer_number_to_merge);
+
+        opts.set_num_levels(cfg.num_levels);
+        opts.set_compression_per_level(&cfg.compression_per_level);
+
+        opts.set_level_zero_file_num_compaction_trigger(cfg.level0_file_num_compaction_trigger);
+        opts.set_target_file_size_base(cfg.target_file_size_base);
+        opts.set_max_bytes_for_level_base(cfg.max_bytes_for_level_base);
+        opts.set_max_bytes_for_level_multiplier(cfg.max_bytes_for_level_multiplier);
+        opts.set_max_compaction_bytes(cfg.max_compaction_bytes);
+        opts.set_level_compaction_dynamic_level_bytes(true);
+
+        opts.set_level_zero_slowdown_writes_trigger(cfg.level0_slowdown_writes_trigger);
+        opts.set_level_zero_stop_writes_trigger(cfg.level0_slowdown_writes_trigger);
+        opts.set_soft_pending_compaction_bytes_limit(cfg.soft_pending_compaction_bytes_limit);
+        opts.set_hard_pending_compaction_bytes_limit(cfg.hard_pending_compaction_bytes_limit);
+
+        opts.set_auto_tuned_ratelimiter(
+            cfg.rate_limiter_bytes_per_sec,
+            cfg.rate_limiter_refill_period,
+            10,
+            cfg.rate_limiter_auto_tuned,
+        );
+
+        let cache = Cache::new_lru_cache(cfg.block_cache_size).expect("new lrc cache");
+
+        let mut blk_opts = BlockBasedOptions::default();
+        blk_opts.set_index_type(BlockBasedIndexType::TwoLevelIndexSearch);
+        blk_opts.set_block_size(cfg.block_size);
+        blk_opts.set_block_cache(&cache);
+        blk_opts.set_cache_index_and_filter_blocks(true);
+        blk_opts.set_bloom_filter(10.0, false);
+        opts.set_block_based_table_factory(&blk_opts);
+
+        opts.create_missing_column_families(true);
+        opts
+    }
+}
+
 impl Default for DbConfig {
     fn default() -> Self {
         DbConfig {

--- a/src/server/src/lib.rs
+++ b/src/server/src/lib.rs
@@ -38,7 +38,7 @@ use std::{path::PathBuf, sync::Arc};
 use engula_client::{ConnManager, RootClient, Router};
 use tonic::async_trait;
 
-use crate::node::{resolver::AddressResolver, StateEngine};
+use crate::node::{engine::RawDb, resolver::AddressResolver, StateEngine};
 pub use crate::{
     bootstrap::run,
     config::*,
@@ -60,7 +60,7 @@ pub(crate) struct Provider {
     pub conn_manager: ConnManager,
     pub root_client: RootClient,
     pub router: Router,
-    pub raw_db: Arc<rocksdb::DB>,
+    pub raw_db: Arc<RawDb>,
     pub state_engine: StateEngine,
 }
 

--- a/src/server/src/node/engine/mod.rs
+++ b/src/server/src/node/engine/mod.rs
@@ -15,6 +15,8 @@
 mod group;
 mod state;
 
+use std::{path::Path, sync::Arc};
+
 pub use self::{
     group::{
         EngineConfig, GroupEngine, RawIterator, Snapshot, SnapshotMode, WriteBatch, WriteStates,
@@ -22,3 +24,98 @@ pub use self::{
     },
     state::StateEngine,
 };
+
+type Result<T> = std::result::Result<T, rocksdb::Error>;
+
+pub struct RawDb {
+    pub options: rocksdb::Options,
+    pub db: rocksdb::DB,
+}
+
+impl RawDb {
+    #[inline]
+    pub fn cf_handle(&self, name: &str) -> Option<Arc<rocksdb::BoundColumnFamily>> {
+        self.db.cf_handle(name)
+    }
+
+    #[inline]
+    pub fn create_cf<N: AsRef<str>>(&self, name: N) -> Result<()> {
+        self.db.create_cf(name, &self.options)
+    }
+
+    #[inline]
+    pub fn drop_cf(&self, name: &str) -> Result<()> {
+        self.db.drop_cf(name)
+    }
+
+    #[inline]
+    pub fn flush_cf(&self, cf: &impl rocksdb::AsColumnFamilyRef) -> Result<()> {
+        self.db.flush_cf(cf)
+    }
+
+    #[inline]
+    pub fn write_opt(
+        &self,
+        batch: rocksdb::WriteBatch,
+        writeopts: &rocksdb::WriteOptions,
+    ) -> Result<()> {
+        self.db.write_opt(batch, writeopts)
+    }
+
+    #[inline]
+    pub fn get_pinned_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &impl rocksdb::AsColumnFamilyRef,
+        key: K,
+    ) -> Result<Option<rocksdb::DBPinnableSlice>> {
+        self.db.get_pinned_cf(cf, key)
+    }
+
+    #[inline]
+    pub fn get_pinned_cf_opt<K: AsRef<[u8]>>(
+        &self,
+        cf: &impl rocksdb::AsColumnFamilyRef,
+        key: K,
+        readopts: &rocksdb::ReadOptions,
+    ) -> Result<Option<rocksdb::DBPinnableSlice>> {
+        self.db.get_pinned_cf_opt(cf, key, readopts)
+    }
+
+    #[inline]
+    pub fn iterator_cf<'a: 'b, 'b>(
+        &'a self,
+        cf_handle: &impl rocksdb::AsColumnFamilyRef,
+        mode: rocksdb::IteratorMode,
+    ) -> rocksdb::DBIteratorWithThreadMode<'b, rocksdb::DB> {
+        self.db.iterator_cf(cf_handle, mode)
+    }
+
+    #[inline]
+    pub fn iterator_cf_opt<'a: 'b, 'b>(
+        &'a self,
+        cf_handle: &impl rocksdb::AsColumnFamilyRef,
+        readopts: rocksdb::ReadOptions,
+        mode: rocksdb::IteratorMode,
+    ) -> rocksdb::DBIteratorWithThreadMode<'b, rocksdb::DB> {
+        self.db.iterator_cf_opt(cf_handle, readopts, mode)
+    }
+
+    #[inline]
+    pub fn ingest_external_file_opts<P: AsRef<Path>>(
+        &self,
+        opts: &rocksdb::IngestExternalFileOptions,
+        paths: Vec<P>,
+    ) -> Result<()> {
+        self.db.ingest_external_file_opts(opts, paths)
+    }
+
+    #[inline]
+    pub fn ingest_external_file_cf_opts<P: AsRef<Path>>(
+        &self,
+        cf: &impl rocksdb::AsColumnFamilyRef,
+        opts: &rocksdb::IngestExternalFileOptions,
+        paths: Vec<P>,
+    ) -> Result<()> {
+        self.db.ingest_external_file_cf_opts(cf, opts, paths)
+    }
+}

--- a/src/server/src/node/engine/state.rs
+++ b/src/server/src/node/engine/state.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use engula_api::server::v1::*;
 use prost::Message;
 
+use super::RawDb;
 use crate::{serverpb::v1::*, Result};
 
 const STATE_CF_NAME: &str = "state";
@@ -35,7 +36,7 @@ pub struct StateEngine
 where
     Self: Send + Sync,
 {
-    raw_db: Arc<rocksdb::DB>,
+    raw_db: Arc<RawDb>,
 }
 
 pub struct ReplicaStateIterator<'a> {
@@ -43,12 +44,9 @@ pub struct ReplicaStateIterator<'a> {
 }
 
 impl StateEngine {
-    pub fn new(raw_db: Arc<rocksdb::DB>) -> Result<Self> {
+    pub fn new(raw_db: Arc<RawDb>) -> Result<Self> {
         if raw_db.cf_handle(STATE_CF_NAME).is_none() {
-            use rocksdb::Options;
-            let mut opts = Options::default();
-            opts.create_missing_column_families(true);
-            raw_db.create_cf(STATE_CF_NAME, &opts)?;
+            raw_db.create_cf(STATE_CF_NAME)?;
         }
         Ok(StateEngine { raw_db })
     }

--- a/src/server/src/node/job/destory_replica.rs
+++ b/src/server/src/node/job/destory_replica.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use tracing::error;
 
 use crate::{
-    node::{metrics::*, GroupEngine, StateEngine},
+    node::{engine::RawDb, metrics::*, GroupEngine, StateEngine},
     raftgroup::destory_storage,
     record_latency,
     runtime::TaskPriority,
@@ -48,7 +48,7 @@ async fn destory_replica(
     group_id: u64,
     replica_id: u64,
     state_engine: StateEngine,
-    raw_db: Arc<rocksdb::DB>,
+    raw_db: Arc<RawDb>,
     raft_engine: Arc<raft_engine::Engine>,
 ) -> Result<()> {
     record_latency!(take_destory_replica_metrics());

--- a/src/server/src/node/mod.rs
+++ b/src/server/src/node/mod.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
 use self::{
-    engine::EngineConfig,
+    engine::{EngineConfig, RawDb},
     job::StateChannel,
     migrate::{MigrateController, ShardChunkStream},
     replica::ReplicaConfig,
@@ -719,7 +719,7 @@ impl Default for NodeConfig {
 
 async fn open_group_engine(
     cfg: &EngineConfig,
-    raw_db: Arc<rocksdb::DB>,
+    raw_db: Arc<RawDb>,
     group_id: u64,
     replica_id: u64,
     replica_state: ReplicaLocalState,


### PR DESCRIPTION
When cf was created before, the default configuration was used. Now options are set to the options exported by config.