### PR TITLE
ci: disable parallel test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,4 +70,4 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --workspace -- --nocapture --quiet
+        args: --workspace -- --nocapture --quiet --test-threads=1


### PR DESCRIPTION
Parallel test might fails since the runner of github action only have 2 cores, see
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources for details.