### PR TITLE
client: fix blocked on recreate pull stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,7 @@ dependencies = [
 name = "engula-client"
 version = "0.4.0"
 dependencies = [
+ "async-stream",
  "crc32fast",
  "ctor",
  "derivative",

--- a/src/client/Cargo.toml
+++ b/src/client/Cargo.toml
@@ -10,6 +10,7 @@ description = "The Engula API."
 [dependencies]
 engula-api = { version = "0.4", path = "../api" }
 
+async-stream = "0.3.3"
 crc32fast = "1.3.2"
 derivative = "2.2.0"
 futures = "0.3.24"

--- a/src/server/src/node/mod.rs
+++ b/src/server/src/node/mod.rs
@@ -446,6 +446,7 @@ impl Node {
                 return Err(Error::GroupNotFound(request.group_id));
             }
         };
+        replica.check_migrating_request_early(request.shard_id)?;
         Ok(ShardChunkStream::new(
             request.shard_id,
             self.cfg.shard_chunk_size,

--- a/src/server/src/node/replica/migrate.rs
+++ b/src/server/src/node/replica/migrate.rs
@@ -182,7 +182,7 @@ impl Replica {
         Ok(())
     }
 
-    fn check_migrating_request_early(&self, shard_id: u64) -> Result<()> {
+    pub fn check_migrating_request_early(&self, shard_id: u64) -> Result<()> {
         let lease_state = self.lease_state.lock().unwrap();
         if !lease_state.is_ready_for_serving() {
             Err(Error::NotLeader(


### PR DESCRIPTION
fix blocked on recreating pull stream

also, add an additional leader check before the return stream in the node

